### PR TITLE
Bug: Use device locale instead of App Locale

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Microsoft.AppCenter.Windows.Shared.projitems
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Microsoft.AppCenter.Windows.Shared.projitems
@@ -63,6 +63,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Storage\Storage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Storage\StorageException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\AbstractDeviceInformationHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\CultureInfoHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IApplicationLifecycleHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IApplicationSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IApplicationSettingsFactory.cs" />

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/AbstractDeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/AbstractDeviceInformationHelper.cs
@@ -2,6 +2,8 @@
 using System.Reflection;
 using System.Threading.Tasks;
 
+using Microsoft.AppCenter.Windows.Shared.Utils;
+
 namespace Microsoft.AppCenter.Utils
 {
     public abstract class AbstractDeviceInformationHelper : IDeviceInformationHelper
@@ -79,7 +81,7 @@ namespace Microsoft.AppCenter.Utils
 
         private string GetLocale()
         {
-            return System.Globalization.CultureInfo.CurrentCulture.Name;
+            return CultureInfoHelper.GetCurrentCulture().Name;
         }
 
         private int GetTimeZoneOffset()

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/CultureInfoHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/CultureInfoHelper.cs
@@ -1,0 +1,50 @@
+﻿using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.AppCenter.Windows.Shared.Utils
+{
+    //https://www.pedrolamas.com/2017/05/03/cultureinfo-changes-in-uwp-part-2/
+    class CultureInfoHelper
+    {
+        private const uint LOCALE_SNAME = 0x0000005c;
+        private const string LOCALE_NAME_USER_DEFAULT = null;
+        private const string LOCALE_NAME_SYSTEM_DEFAULT = "!x-sys-default-locale";
+        private const int BUFFER_SIZE = 530;
+        
+        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetLocaleInfoEx(string lpLocaleName, uint LCType, StringBuilder lpLCData, int cchData);
+
+        public static CultureInfo GetCurrentCulture()
+        {
+            var name = InvokeGetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SNAME);
+
+            if (name == null)
+            {
+                name = InvokeGetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, LOCALE_SNAME);
+
+                if (name == null)
+                {
+                    // If system default doesn't work, use invariant
+                    return CultureInfo.InvariantCulture;
+                }
+            }
+
+            return new CultureInfo(name);
+        }
+
+        private static string InvokeGetLocaleInfoEx(string lpLocaleName, uint LCType)
+        {
+            var buffer = new StringBuilder(BUFFER_SIZE);
+
+            var resultCode = GetLocaleInfoEx(lpLocaleName, LCType, buffer, BUFFER_SIZE);
+
+            if (resultCode > 0)
+            {
+                return buffer.ToString();
+            }
+
+            return null;
+        }
+    }
+}

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/CultureInfoHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/CultureInfoHelper.cs
@@ -4,13 +4,13 @@ using System.Text;
 
 namespace Microsoft.AppCenter.Windows.Shared.Utils
 {
-    //https://www.pedrolamas.com/2017/05/03/cultureinfo-changes-in-uwp-part-2/
+    // https://www.pedrolamas.com/2017/05/03/cultureinfo-changes-in-uwp-part-2/
     class CultureInfoHelper
     {
-        // relative location of system locale name
+        // Relative location of system locale name.
         private const uint LOCALE_SNAME = 0x0000005c;
 
-        // Constants used by the National Language Support reference
+        // Constants used by the National Language Support reference.
         private const string LOCALE_NAME_USER_DEFAULT = null;
         private const string LOCALE_NAME_SYSTEM_DEFAULT = "!x-sys-default-locale";
 
@@ -22,18 +22,15 @@ namespace Microsoft.AppCenter.Windows.Shared.Utils
         public static CultureInfo GetCurrentCulture()
         {
             var name = InvokeGetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SNAME);
-
             if (name == null)
             {
                 name = InvokeGetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, LOCALE_SNAME);
-
                 if (name == null)
                 {
-                    // If system default doesn't work, use invariant
+                    // If system default doesn't work, use invariant.
                     return CultureInfo.InvariantCulture;
                 }
             }
-
             return new CultureInfo(name);
         }
 
@@ -41,12 +38,10 @@ namespace Microsoft.AppCenter.Windows.Shared.Utils
         {
             var buffer = new StringBuilder(BUFFER_SIZE);
             var resultCode = GetLocaleInfoEx(lpLocaleName, LCType, buffer, BUFFER_SIZE);
-
             if (resultCode > 0)
             {
                 return buffer.ToString();
             }
-
             return null;
         }
     }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/CultureInfoHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/CultureInfoHelper.cs
@@ -7,9 +7,13 @@ namespace Microsoft.AppCenter.Windows.Shared.Utils
     //https://www.pedrolamas.com/2017/05/03/cultureinfo-changes-in-uwp-part-2/
     class CultureInfoHelper
     {
+        // relative location of system locale name
         private const uint LOCALE_SNAME = 0x0000005c;
+
+        // Constants used by the National Language Support reference
         private const string LOCALE_NAME_USER_DEFAULT = null;
         private const string LOCALE_NAME_SYSTEM_DEFAULT = "!x-sys-default-locale";
+
         private const int BUFFER_SIZE = 530;
         
         [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode)]
@@ -36,7 +40,6 @@ namespace Microsoft.AppCenter.Windows.Shared.Utils
         private static string InvokeGetLocaleInfoEx(string lpLocaleName, uint LCType)
         {
             var buffer = new StringBuilder(BUFFER_SIZE);
-
             var resultCode = GetLocaleInfoEx(lpLocaleName, LCType, buffer, BUFFER_SIZE);
 
             if (resultCode > 0)

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/packages.config
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/packages.config
@@ -15,7 +15,7 @@
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net452" />
   <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net452" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.IO.Compression" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.UWP/Push.cs
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.UWP/Push.cs
@@ -12,10 +12,10 @@ using Windows.ApplicationModel.Activation;
 using Windows.Data.Xml.Dom;
 using Windows.Networking.PushNotifications;
 
+using WindowsPushNotificationReceivedEventArgs = Windows.Networking.PushNotifications.PushNotificationReceivedEventArgs;
+
 namespace Microsoft.AppCenter.Push
 {
-    using WindowsPushNotificationReceivedEventArgs = Windows.Networking.PushNotifications.PushNotificationReceivedEventArgs;
-
     public partial class Push
     {
         private PushNotificationChannel _channel;
@@ -112,7 +112,7 @@ namespace Microsoft.AppCenter.Push
 
         private void OnPushNotificationReceivedHandler(PushNotificationChannel sender, WindowsPushNotificationReceivedEventArgs e)
         {
-            XmlDocument content;
+            XmlDocument content = null;
             if (e.NotificationType == PushNotificationType.Toast && (content = e.ToastNotification?.Content) != null)
             {
                 AppCenterLog.Debug(LogTag, $"Received push notification payload: {content.GetXml()}");


### PR DESCRIPTION
Not very happy with this solution but it seems pretty accepted as the way to always get the device/system locale.  See link in the helper class.

I think, though, that if the implementation of the DLL changes this may break, which isn't great.