### PR TITLE
Use reflection to accept SQLite 1.5

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/AppCenter.cs
@@ -193,7 +193,22 @@ namespace Microsoft.AppCenter
         {
             lock (AppCenterLock)
             {
-                Instance.StartInstanceAndConfigure(appSecret, services);
+                try
+                {
+                    Instance.InstanceConfigure(appSecret);
+                }
+                catch (AppCenterException ex)
+                {
+                    AppCenterLog.Error(AppCenterLog.LogTag, ConfigurationErrorMessage, ex);
+                }
+                try
+                {
+                    Instance.StartInstance(services);
+                }
+                catch (AppCenterException ex)
+                {
+                    AppCenterLog.Error(AppCenterLog.LogTag, StartErrorMessage, ex);
+                }
             }
         }
  
@@ -400,18 +415,6 @@ namespace Microsoft.AppCenter
             AppCenterLog.Info(AppCenterLog.LogTag, $"'{service.GetType().Name}' service started.");
         }
 
-        public void StartInstanceAndConfigure(string appSecret, params Type[] services)
-        {
-            try
-            {
-                InstanceConfigure(appSecret);
-                StartInstance(services);
-            }
-            catch (AppCenterException ex)
-            {
-                AppCenterLog.Warn(AppCenterLog.LogTag, ex.Message);
-            }
-        }
         internal Guid InstanceCorrelationId = Guid.Empty;
 
         // We don't support Distribute in UWP.

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
@@ -325,7 +325,7 @@ namespace Microsoft.AppCenter.Storage
             {
                 await _storageAdapter.CreateTableAsync<LogEntry>().ConfigureAwait(false);
             }
-            catch (StorageException e)
+            catch (Exception e)
             {
                 AppCenterLog.Error(AppCenterLog.LogTag, "An error occurred while initializing storage", e);
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using SQLite;
 using Microsoft.AppCenter.Ingestion.Models;
 using Microsoft.AppCenter.Ingestion.Models.Serialization;
+using Newtonsoft.Json;
+using SQLite;
 
 namespace Microsoft.AppCenter.Storage
 {
@@ -41,7 +42,7 @@ namespace Microsoft.AppCenter.Storage
         /// <summary>
         /// Creates an instance of Storage
         /// </summary>
-        public Storage() : this(new StorageAdapter(Database))
+        public Storage() : this(DefaultAdapter())
         {
         }
 
@@ -53,6 +54,25 @@ namespace Microsoft.AppCenter.Storage
             _storageAdapter = adapter;
             _queue.Add(new Task(() => InitializeDatabaseAsync().Wait()));
             _queueFlushTask = Task.Run(FlushQueueAsync);
+        }
+
+        private static IStorageAdapter DefaultAdapter()
+        {
+            try
+            {
+                return new StorageAdapter(Database);
+            }
+            catch (FileLoadException e)
+            {
+                if (e.Message.Contains("SQLite-net"))
+                {
+                    AppCenterLog.Error(AppCenterLog.LogTag,
+                        "If you are using sqlite-net-pcl version 1.4.118, please use a different version. " +
+                        "There is a known bug in this version that will prevent App Center from working properly.");
+                    throw new StorageException("Cannot initialize SQLite library.", e);
+                }
+                throw;
+            }
         }
 
         /// <summary>

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using SQLite;
 
@@ -19,7 +20,13 @@ namespace Microsoft.AppCenter.Storage
         {
             try
             {
-                await _dbConnection.CreateTableAsync<T>().ConfigureAwait(false);
+                // In SQLite-net 1.5 return type was changed.
+                // Using reflection to accept newer library version.
+                var task = (Task)_dbConnection.GetType()
+                    .GetMethod("CreateTableAsync", new [] { typeof(CreateFlags) })
+                    .MakeGenericMethod(typeof(T))
+                    .Invoke(_dbConnection, new object[] { CreateFlags.None });
+                await task.ConfigureAwait(false);
             }
             catch (SQLiteException e)
             {


### PR DESCRIPTION
Fixes
```C#
System.MissingMethodException: Method not found: 'System.Threading.Tasks.Task`1<SQLite.CreateTablesResult> SQLite.SQLiteAsyncConnection.CreateTableAsync(SQLite.CreateFlags)'.
   at Microsoft.AppCenter.Storage.StorageAdapter.<CreateTableAsync>d__2`1.MoveNext()
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.AppCenter.Storage.StorageAdapter.CreateTableAsync[T]()
   at Microsoft.AppCenter.Storage.Storage.<InitializeDatabaseAsync>d__19.MoveNext()
```
with SQLite-net 1.5