### PR TITLE
Use geographic region as country code source

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/App.xaml.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Globalization;
-using System.Threading.Tasks;
+using Microsoft.AppCenter;
+using Microsoft.AppCenter.Push;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.Globalization;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using Microsoft.AppCenter;
-using Microsoft.AppCenter.Analytics;
-using Microsoft.AppCenter.Push;
 
 namespace Contoso.Forms.Demo.UWP
 {
@@ -28,7 +26,8 @@ namespace Contoso.Forms.Demo.UWP
             // Note that the country code provided does not reflect the physical device location, but rather the
             // country that corresponds to the culture it uses. You may wish to retrieve the country code using
             // a different means, such as device location.
-            AppCenter.SetCountryCode(RegionInfo.CurrentRegion.TwoLetterISORegionName);
+            var geographicRegion = new GeographicRegion();
+            AppCenter.SetCountryCode(geographicRegion.CodeTwoLetter);
             InitializeComponent();
             Suspending += OnSuspending;
         }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Globalization;
 using Microsoft.AppCenter;
+using Microsoft.AppCenter.Push;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.Globalization;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using Microsoft.AppCenter.Push;
 
 namespace Contoso.Forms.Puppet.UWP
 {
@@ -26,7 +26,8 @@ namespace Contoso.Forms.Puppet.UWP
             // Note that the country code provided does not reflect the physical device location, but rather the
             // country that corresponds to the culture it uses. You may wish to retrieve the country code using
             // a different means, such as device location.
-            AppCenter.SetCountryCode(RegionInfo.CurrentRegion.TwoLetterISORegionName);
+            var geographicRegion = new GeographicRegion();
+            AppCenter.SetCountryCode(geographicRegion.CodeTwoLetter);
             InitializeComponent();
             Suspending += OnSuspending;
         }


### PR DESCRIPTION
`RegionInfo.CurrentRegion` uses `CultureInfo.CurrentCulture` as the basis for the region it returns.

The home region is usually set when Windows is installed and is available in
**Settings → Time & language → Region & language → Country or region**.
`GeographicRegion` allows to get this value.