### PR TITLE
[Windows] Fix channel issues

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -21,7 +21,8 @@ namespace Microsoft.AppCenter.Channel
         private readonly IStorage _storage;
         private readonly IIngestion _ingestion;
         private readonly IDeviceInformationHelper _deviceInfoHelper = new DeviceInformationHelper();
-        private readonly Dictionary<string, List<Log>> _sendingBatches = new Dictionary<string, List<Log>>();
+        private readonly IDictionary<string, List<Log>> _sendingBatches = new Dictionary<string, List<Log>>();
+        private readonly ISet<IServiceCall> _calls = new HashSet<IServiceCall>();
         private readonly int _maxParallelBatches;
         private readonly int _maxLogsPerBatch;
         private long _pendingLogCount;
@@ -100,8 +101,8 @@ namespace Microsoft.AppCenter.Channel
         /// Invoked when a log failed to send properly.
         /// </summary>
         public event EventHandler<FailedToSendLogEventArgs> FailedToSendLog;
-        #endregion
 
+        #endregion
 
         /// <summary>
         /// Enable or disable this channel unit.
@@ -147,12 +148,16 @@ namespace Microsoft.AppCenter.Channel
                 if (discardLogs)
                 {
                     AppCenterLog.Warn(AppCenterLog.LogTag, "Channel is disabled; logs are discarded");
+                    AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke SendingLog event for channel '{Name}'");
                     SendingLog?.Invoke(this, new SendingLogEventArgs(log));
+                    AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke FailedToSendLog event for channel '{Name}'");
                     FailedToSendLog?.Invoke(this, new FailedToSendLogEventArgs(log, new CancellationException()));
                     return;
                 }
+                AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke EnqueuingLog event for channel '{Name}'");
                 EnqueuingLog?.Invoke(this, new EnqueuingLogEventArgs(log));
                 await PrepareLogAsync(log, state).ConfigureAwait(false);
+                AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke FilteringLog event for channel '{Name}'");
                 var filteringLogEventArgs = new FilteringLogEventArgs(log);
                 FilteringLog?.Invoke(this, filteringLogEventArgs);
                 if (filteringLogEventArgs.FilterRequested)
@@ -250,6 +255,7 @@ namespace Microsoft.AppCenter.Channel
 
         private void Resume(State state)
         {
+            AppCenterLog.Verbose(AppCenterLog.LogTag, $"Resume channel: '{Name}'");
             try
             {
                 using (_mutex.GetLock(state))
@@ -261,15 +267,17 @@ namespace Microsoft.AppCenter.Channel
             }
             catch (StatefulMutexException)
             {
-                AppCenterLog.Warn(AppCenterLog.LogTag, "The Resume operation has been cancelled");
+                AppCenterLog.Warn(AppCenterLog.LogTag, "The resume operation has been cancelled");
             }
             CheckPendingLogs(state);
         }
 
         private void Suspend(State state, bool deleteLogs, Exception exception)
         {
+            AppCenterLog.Verbose(AppCenterLog.LogTag, $"Suspend channel: '{Name}'");
             try
             {
+                List<string> sendingBatches = null;
                 List<Log> unsentLogs = null;
                 using (_mutex.GetLock(state))
                 {
@@ -278,6 +286,7 @@ namespace Microsoft.AppCenter.Channel
                     _discardLogs = deleteLogs;
                     if (deleteLogs)
                     {
+                        sendingBatches = _sendingBatches.Keys.ToList();
                         unsentLogs = _sendingBatches.Values.SelectMany(batch => batch).ToList();
                         _sendingBatches.Clear();
                     }
@@ -287,65 +296,69 @@ namespace Microsoft.AppCenter.Channel
                 {
                     foreach (var log in unsentLogs)
                     {
+                        AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke FailedToSendLog event for channel '{Name}'");
                         FailedToSendLog?.Invoke(this, new FailedToSendLogEventArgs(log, exception));
                     }
                 }
                 if (deleteLogs)
                 {
-                    try
-                    {
-                        _ingestion.Close();
-                    }
-                    catch (IngestionException e)
-                    {
-                        AppCenterLog.Error(AppCenterLog.LogTag, "Failed to close ingestion", e);
-                    }
+                    List<IServiceCall> calls;
                     using (_mutex.GetLock(state))
                     {
+                        calls = _calls.ToList();
+                        _calls.Clear();
                         _pendingLogCount = 0;
-                        TriggerDeleteLogsOnSuspending();
+                        TriggerDeleteLogsOnSuspending(sendingBatches);
+                    }
+                    foreach (var call in calls)
+                    {
+                        call.Cancel();
                     }
                 }
                 _storage.ClearPendingLogState(Name);
             }
             catch (StatefulMutexException)
             {
-                AppCenterLog.Warn(AppCenterLog.LogTag, "The Suspend operation has been cancelled");
+                AppCenterLog.Warn(AppCenterLog.LogTag, "The suspend operation has been cancelled");
             }
         }
 
-        private void TriggerDeleteLogsOnSuspending()
+        private void TriggerDeleteLogsOnSuspending(IList<string> sendingBatches)
         {
             if (SendingLog == null && FailedToSendLog == null)
             {
                 _storage.DeleteLogs(Name);
                 return;
             }
-            SignalDeletingLogs().ContinueWith(completedTask => _storage.DeleteLogs(Name));
+            SignalDeletingLogs(sendingBatches).ContinueWith(completedTask => _storage.DeleteLogs(Name));
         }
 
-        private Task SignalDeletingLogs()
+        private async Task SignalDeletingLogs(IList<string> sendingBatches)
         {
             var logs = new List<Log>();
-            return _storage.GetLogsAsync(Name, ClearBatchSize, logs)
-                .ContinueWith(completedTask =>
+            try
+            {
+                do
                 {
-                    if (completedTask.IsFaulted)
+                    var batchId = await _storage.GetLogsAsync(Name, ClearBatchSize, logs).ConfigureAwait(false);
+                    if (sendingBatches.Contains(batchId))
                     {
-                        AppCenterLog.Warn(AppCenterLog.LogTag,
-                            "Failed to invoke events for logs being deleted.");
-                        return;
+                        continue;
                     }
                     foreach (var log in logs)
                     {
+                        AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke SendingLog for channel '{Name}'");
                         SendingLog?.Invoke(this, new SendingLogEventArgs(log));
+                        AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke FailedToSendLog event for channel '{Name}'");
                         FailedToSendLog?.Invoke(this, new FailedToSendLogEventArgs(log, new CancellationException()));
                     }
-                    if (logs.Count >= ClearBatchSize)
-                    {
-                        SignalDeletingLogs();
-                    }
-                });
+                }
+                while (logs.Count >= ClearBatchSize);
+            }
+            catch
+            {
+                AppCenterLog.Warn(AppCenterLog.LogTag, "Failed to invoke events for logs being deleted.");
+            }
         }
 
         private async Task TriggerIngestionAsync(State state)
@@ -357,12 +370,12 @@ namespace Microsoft.AppCenter.Channel
                     return;
                 }
                 AppCenterLog.Debug(AppCenterLog.LogTag,
-                    $"triggerIngestion({Name}) pendingLogCount={_pendingLogCount}");
+                    $"TriggerIngestion({Name}) pending log count: {_pendingLogCount}");
                 _batchScheduled = false;
                 if (_sendingBatches.Count >= _maxParallelBatches)
                 {
                     AppCenterLog.Debug(AppCenterLog.LogTag,
-                        "Already sending " + _maxParallelBatches + " batches of analytics data to the server");
+                        $"Already sending {_maxParallelBatches} batches of analytics data to the server");
                     return;
                 }
             }
@@ -379,7 +392,24 @@ namespace Microsoft.AppCenter.Channel
                 }
                 try
                 {
-                    TriggerIngestion(state, logs, batchId);
+                    // Before sending logs, trigger the sending event for this channel
+                    if (SendingLog != null)
+                    {
+                        foreach (var log in logs)
+                        {
+                            AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke SendingLog event for channel '{Name}'");
+                            SendingLog?.Invoke(this, new SendingLogEventArgs(log));
+                        }
+                    }
+
+                    // If the optional Install ID has no value, default to using empty GUID
+                    var installId = await AppCenter.GetInstallIdAsync().ConfigureAwait(false) ?? Guid.Empty;
+                    var ingestionCall = _ingestion.Call(_appSecret, installId, logs);
+                    using (await _mutex.GetLockAsync(state).ConfigureAwait(false))
+                    {
+                        _calls.Add(ingestionCall);
+                    }
+                    ingestionCall.ContinueWith(call => HandleSendingResult(state, batchId, call));
                     CheckPendingLogs(state);
                 }
                 catch (StorageException)
@@ -389,40 +419,65 @@ namespace Microsoft.AppCenter.Channel
             }
         }
 
-        private void TriggerIngestion(State state, IList<Log> logs, string batchId)
+        private void HandleSendingResult(State state, string batchId, IServiceCall call)
         {
-            // Before sending logs, trigger the sending event for this channel
-            if (SendingLog != null)
+            // Get a lock without checking the state here.
+            using (_mutex.GetLock())
             {
-                foreach (var eventArgs in logs.Select(log => new SendingLogEventArgs(log)))
-                {
-                    SendingLog?.Invoke(this, eventArgs);
-                }
+                _calls.Remove(call);
             }
-
-            // If the optional Install ID has no value, default to using empty GUID
-            // TODO When InstallId will really be async, we should not use Result anymore
-            var rawInstallId = AppCenter.GetInstallIdAsync().Result;
-            var installId = rawInstallId.HasValue ? rawInstallId.Value : Guid.Empty;
-            _ingestion.Call(_appSecret, installId, logs).ContinueWith(call =>
+            try
             {
-                var ingestionException = call.Exception;
-                if (ingestionException == null)
+                if (call.IsCanceled)
                 {
-                    HandleSendingSuccess(state, batchId);
+                    AppCenterLog.Debug(AppCenterLog.LogTag, $"Sending logs for channel '{Name}', batch '{batchId}' canceled");
+                    HandleSendingFailure(state, batchId, new CancellationException());
+                }
+                else if (call.IsFaulted)
+                {
+                    AppCenterLog.Error(AppCenterLog.LogTag, $"Sending logs for channel '{Name}', batch '{batchId}' failed: {call.Exception?.Message}");
+                    var isRecoverable = call.Exception is IngestionException ingestionException && ingestionException.IsRecoverable;
+                    if (isRecoverable)
+                    {
+                        using (_mutex.GetLock(state))
+                        {
+                            var removedLogs = _sendingBatches[batchId];
+                            _sendingBatches.Remove(batchId);
+                            _pendingLogCount += removedLogs.Count;
+                        }
+                    }
+                    else
+                    {
+                        HandleSendingFailure(state, batchId, call.Exception);
+                    }
+                    Suspend(state, !isRecoverable, call.Exception);
                 }
                 else
                 {
-                    HandleSendingFailure(state, batchId, ingestionException);
+                    HandleSendingSuccess(state, batchId);
                 }
-            });
+            }
+            catch (StatefulMutexException)
+            {
+                AppCenterLog.Debug(AppCenterLog.LogTag, "Handle sending operation has been canceled. Callbacks were invoked when channel suspended.");
+            }
         }
 
         private void HandleSendingSuccess(State state, string batchId)
         {
-            if (!_mutex.IsCurrent(state))
+            List<Log> removedLogs;
+            using (_mutex.GetLock(state))
             {
-                return;
+                removedLogs = _sendingBatches[batchId];
+                _sendingBatches.Remove(batchId);
+            }
+            if (SentLog != null)
+            {
+                foreach (var log in removedLogs)
+                {
+                    AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke SentLog event for channel '{Name}'");
+                    SentLog?.Invoke(this, new SentLogEventArgs(log));
+                }
             }
             try
             {
@@ -432,52 +487,31 @@ namespace Microsoft.AppCenter.Channel
             {
                 AppCenterLog.Warn(AppCenterLog.LogTag, $"Could not delete logs for batch {batchId}", e);
             }
-            finally
-            {
-                List<Log> removedLogs;
-                using (_mutex.GetLock(state))
-                {
-                    removedLogs = _sendingBatches[batchId];
-                    _sendingBatches.Remove(batchId);
-                }
-                if (SentLog != null)
-                {
-                    foreach (var log in removedLogs)
-                    {
-                        SentLog?.Invoke(this, new SentLogEventArgs(log));
-                    }
-                }
-            }
         }
 
-        private void HandleSendingFailure(State state, string batchId, Exception e)
+        private void HandleSendingFailure(State state, string batchId, Exception exception)
         {
-            AppCenterLog.Error(AppCenterLog.LogTag, $"Sending logs for channel '{Name}', batch '{batchId}' failed: {e?.Message}");
+            List<Log> removedLogs;
+            using (_mutex.GetLock(state))
+            {
+                removedLogs = _sendingBatches[batchId];
+                _sendingBatches.Remove(batchId);
+            }
+            if (FailedToSendLog != null)
+            {
+                foreach (var log in removedLogs)
+                {
+                    AppCenterLog.Verbose(AppCenterLog.LogTag, $"Invoke FailedToSendLog event for channel '{Name}'");
+                    FailedToSendLog?.Invoke(this, new FailedToSendLogEventArgs(log, exception));
+                }
+            }
             try
             {
-                var isRecoverable = e is IngestionException ingestionException && ingestionException.IsRecoverable;
-                List<Log> removedLogs;
-                using (_mutex.GetLock(state))
-                {
-                    removedLogs = _sendingBatches[batchId];
-                    _sendingBatches.Remove(batchId);
-                    if (isRecoverable)
-                    {
-                        _pendingLogCount += removedLogs.Count;
-                    }
-                }
-                if (!isRecoverable && FailedToSendLog != null)
-                {
-                    foreach (var log in removedLogs)
-                    {
-                        FailedToSendLog?.Invoke(this, new FailedToSendLogEventArgs(log, e));
-                    }
-                }
-                Suspend(state, !isRecoverable, e);
+                _storage.DeleteLogs(Name, batchId);
             }
-            catch (StatefulMutexException)
+            catch (StorageException e)
             {
-                AppCenterLog.Debug(AppCenterLog.LogTag, "Handle sending failure operation has been canceled. Callbacks were invoked when channel suspended.");
+                AppCenterLog.Warn(AppCenterLog.LogTag, $"Could not delete logs for batch {batchId}", e);
             }
         }
 
@@ -518,7 +552,7 @@ namespace Microsoft.AppCenter.Channel
         }
 
         /// <summary>
-        /// Stop sending logs.
+        /// Stop all calls in progress and deactivate this channel.
         /// </summary>
         /// <returns>The Task to represent this async operation.</returns>
         public Task ShutdownAsync()

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/ChannelGroup.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/ChannelGroup.cs
@@ -103,6 +103,7 @@ namespace Microsoft.AppCenter.Channel
         public async Task ShutdownAsync()
         {
             ThrowIfDisposed();
+            var tasks = new List<Task>();
             lock (_channelGroupLock)
             {
                 if (_isShutdown)
@@ -111,10 +112,7 @@ namespace Microsoft.AppCenter.Channel
                     return;
                 }
                 _isShutdown = true;
-            }
-            var tasks = new List<Task>();
-            lock (_channelGroupLock)
-            {
+                _ingestion.Close();
                 foreach (var channel in _channels)
                 {
                     tasks.Add(channel.ShutdownAsync());

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AppCenter.Channel;
 using Microsoft.AppCenter.Ingestion;
 using Microsoft.AppCenter.Storage;
@@ -9,6 +10,8 @@ using Moq;
 
 namespace Microsoft.AppCenter.Test.Channel
 {
+    using Channel = Microsoft.AppCenter.Channel.Channel;
+
     [TestClass]
     public class ChannelGroupTest
     {
@@ -45,7 +48,7 @@ namespace Microsoft.AppCenter.Test.Channel
         {
             const string channelName = "some_channel";
             var addedChannel =
-                _channelGroup.AddChannel(channelName, 2, TimeSpan.FromSeconds(3), 3) as Microsoft.AppCenter.Channel.Channel;
+                _channelGroup.AddChannel(channelName, 2, TimeSpan.FromSeconds(3), 3) as Channel;
 
             Assert.IsNotNull(addedChannel);
             Assert.AreEqual(channelName, addedChannel.Name);
@@ -168,8 +171,8 @@ namespace Microsoft.AppCenter.Test.Channel
 
             foreach (var channelMock in channelMocks.Select(mock => mock as Mock<IChannelUnit>))
             {
-                channelMock.Verify(channel => channel.SetEnabled(It.Is<bool>(p => p)), Times.Once());
-                channelMock.Verify(channel => channel.SetEnabled(It.Is<bool>(p => !p)), Times.Once());
+                channelMock.Verify(channel => channel.SetEnabled(true), Times.Once);
+                channelMock.Verify(channel => channel.SetEnabled(false), Times.Once);
             }
         }
 
@@ -184,15 +187,16 @@ namespace Microsoft.AppCenter.Test.Channel
         /// Veriy that all channels are disabled after channel group disabling
         /// </summary>
         [TestMethod]
-        public void TestShutdownChannelGroup()
+        public async Task TestShutdownChannelGroup()
         {
             const string channelName = "some_channel";
             var addedChannel =
-                _channelGroup.AddChannel(channelName, 2, TimeSpan.FromSeconds(3), 3) as Microsoft.AppCenter.Channel.Channel;
+                _channelGroup.AddChannel(channelName, 2, TimeSpan.FromSeconds(3), 3) as Channel;
 
-            _channelGroup.ShutdownAsync().RunNotAsync();
+            await _channelGroup.ShutdownAsync();
 
             Assert.IsFalse(addedChannel.IsEnabled);
+            _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Once);
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
@@ -13,22 +13,19 @@ using Moq;
 
 namespace Microsoft.AppCenter.Test.Channel
 {
+    using Channel = Microsoft.AppCenter.Channel.Channel;
+
     [TestClass]
     public class ChannelTest
     {
         private AggregateException _unobservedTaskException;
         private Mock<IIngestion> _mockIngestion;
-        private Microsoft.AppCenter.Channel.Channel _channel;
+        private Channel _channel;
         private IStorage _storage;
 
-        private const string ChannelName = "channelName";
+        private const string ChannelName = "test";
         private const int MaxLogsPerBatch = 3;
-        private readonly TimeSpan _batchTimeSpan = TimeSpan.FromSeconds(1);
         private const int MaxParallelBatches = 3;
-        private readonly string _appSecret = Guid.NewGuid().ToString();
-
-        // We wait tasks now and don't need wait more
-        private const int DefaultWaitTime = 500;
 
         // Event semaphores for invokation verification
         private const int SendingLogSemaphoreIdx = 0;
@@ -36,9 +33,7 @@ namespace Microsoft.AppCenter.Test.Channel
         private const int FailedToSendLogSemaphoreIdx = 2;
         private const int EnqueuingLogSemaphoreIdx = 3;
         private const int FilteringLogSemaphoreIdx = 4;
-        private readonly List<SemaphoreSlim> _eventSemaphores = new List<SemaphoreSlim> { new SemaphoreSlim(0), new SemaphoreSlim(0), new SemaphoreSlim(0), new SemaphoreSlim(0), new SemaphoreSlim(0) };
-
-        public TestContext TestContext { get;set;}
+        private List<SemaphoreSlim> _eventSemaphores;
 
         public ChannelTest()
         {
@@ -50,8 +45,8 @@ namespace Microsoft.AppCenter.Test.Channel
         {
             _unobservedTaskException = null;
             _mockIngestion = new Mock<IIngestion>();
-            MakeIngestionCallsSucceed();
-            SetChannelWithTimeSpan(_batchTimeSpan);
+            SetupIngestionCallSucceed();
+            SetChannelWithTimeSpan(TimeSpan.FromSeconds(1));
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
             AppCenterLog.Level = LogLevel.Verbose;
@@ -114,7 +109,7 @@ namespace Microsoft.AppCenter.Test.Channel
         /// Verify that enqueuing a log passes the same log reference to enqueue event argument
         /// </summary>
         [TestMethod]
-        public void EnqueuedLogsAreSame()
+        public async Task EnqueuedLogsAreSame()
         {
             var log = new TestLog();
             var sem = new SemaphoreSlim(0);
@@ -124,113 +119,109 @@ namespace Microsoft.AppCenter.Test.Channel
                 sem.Release();
             };
 
-            _channel.EnqueueAsync(log).RunNotAsync();
-            Assert.IsTrue(sem.Wait(DefaultWaitTime));
+            await _channel.EnqueueAsync(log);
+            Assert.IsTrue(sem.Wait(0));
         }
 
         /// <summary>
         /// Verify that when a batch reaches its capacity, it is sent immediately
         /// </summary>
         [TestMethod]
-        public void EnqueueMaxLogs()
+        public async Task EnqueueMaxLogs()
         {
             SetChannelWithTimeSpan(TimeSpan.FromHours(1));
             for (var i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-            Assert.IsTrue(SendingLogOccurred(1));
+            VerifySendingLog(MaxLogsPerBatch);
         }
 
         /// <summary>
         /// Verify that when channel is disabled, sent event is not triggered
         /// </summary>
         [TestMethod]
-        public void EnqueueWhileDisabled()
+        public async Task EnqueueWhileDisabled()
         {
             _channel.SetEnabled(false);
             var log = new TestLog();
-            _channel.EnqueueAsync(log).RunNotAsync();
-            Assert.IsTrue(FailedToSendLogOccurred(1));
-            Assert.IsFalse(EnqueuingLogOccurred(1));
+            await _channel.EnqueueAsync(log);
+            VerifyFailedToSendLog(1);
+            VerifyEnqueuingLog(0);
         }
 
         [TestMethod]
-        public void ChannelInvokesFilteringLogEvent()
+        public async Task ChannelInvokesFilteringLogEvent()
         {
             for (var i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-
-            Assert.IsTrue(FilteringLogOccurred(MaxLogsPerBatch));
+            VerifyFilteringLog(MaxLogsPerBatch);
         }
 
         /// <summary>
         /// Validate filtering out a log
         /// </summary>
         [TestMethod]
-        public void FilterLogShouldNotSend()
+        public async Task FilterLogShouldNotSend()
         {
             _channel.FilteringLog += (sender, args) => args.FilterRequested = true;
             for (int i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-            Assert.IsTrue(FilteringLogOccurred(MaxLogsPerBatch));
-            Assert.IsFalse(SendingLogOccurred(MaxLogsPerBatch));
-            Assert.IsFalse(SentLogOccurred(MaxLogsPerBatch));
+            VerifyFilteringLog(MaxLogsPerBatch);
+            VerifySendingLog(0);
+            VerifySentLog(0);
         }
 
         /// <summary>
         /// Validate filters can cancel each other
         /// </summary>
         [TestMethod]
-        public void FilterLogThenCancelFilterLogInAnotherHandlerShouldSend()
+        public async Task FilterLogThenCancelFilterLogInAnotherHandlerShouldSend()
         {
             _channel.FilteringLog += (sender, args) => args.FilterRequested = true;
             _channel.FilteringLog += (sender, args) => args.FilterRequested = false;
             for (int i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-            Assert.IsTrue(FilteringLogOccurred(MaxLogsPerBatch));
-            Assert.IsTrue(SendingLogOccurred(MaxLogsPerBatch));
-            Assert.IsTrue(SentLogOccurred(MaxLogsPerBatch));
+            VerifyFilteringLog(MaxLogsPerBatch);
+            VerifySendingLog(MaxLogsPerBatch);
+            VerifySentLog(MaxLogsPerBatch);
         }
 
         [TestMethod]
-        public void ChannelInvokesSendingLogEvent()
+        public async Task ChannelInvokesSendingLogEvent()
         {
             for (var i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-
-            Assert.IsTrue(SendingLogOccurred(MaxLogsPerBatch));
+            VerifySendingLog(MaxLogsPerBatch);
         }
 
         [TestMethod]
-        public void ChannelInvokesSentLogEvent()
+        public async Task ChannelInvokesSentLogEvent()
         {
             for (var i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-
-            Assert.IsTrue(SentLogOccurred(MaxLogsPerBatch));
+            VerifySentLog(MaxLogsPerBatch);
         }
 
         [TestMethod]
-        public void ChannelInvokesFailedToSendLogEvent()
+        public async Task ChannelInvokesFailedToSendLogEvent()
         {
-            MakeIngestionCallsFail(new Exception());
+            SetupIngestionCallFail(new Exception());
             for (var i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-
-            Assert.IsTrue(FailedToSendLogOccurred(MaxLogsPerBatch));
+            VerifyFailedToSendLog(MaxLogsPerBatch);
         }
 
         /// <summary>
@@ -250,48 +241,46 @@ namespace Microsoft.AppCenter.Test.Channel
         /// Validate that channel will send log after enabling
         /// </summary>
         [TestMethod]
-        public void ChannelInvokesSendingLogEventAfterEnabling()
+        public async Task ChannelInvokesSendingLogEventAfterEnabling()
         {
-            _channel.ShutdownAsync().RunNotAsync();
+            await _channel.ShutdownAsync();
             for (int i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
-
             _channel.SetEnabled(true);
-
-            Assert.IsTrue(SendingLogOccurred(MaxLogsPerBatch));
+            VerifySendingLog(MaxLogsPerBatch);
         }
 
         /// <summary>
         /// Validate that FailedToSendLog calls when channel is disabled
         /// </summary>
         [TestMethod]
-        public void ChannelInvokesFailedToSendLogEventAfterDisabling()
+        public async Task ChannelInvokesFailedToSendLogEventAfterDisabling()
         {
             _channel.SetEnabled(false);
             for (int i = 0; i < MaxLogsPerBatch; ++i)
             {
-                _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+                await _channel.EnqueueAsync(new TestLog());
             }
 
-            Assert.IsTrue(SendingLogOccurred(MaxLogsPerBatch));
-            Assert.IsTrue(FailedToSendLogOccurred(MaxLogsPerBatch));
+            VerifySendingLog(MaxLogsPerBatch);
+            VerifyFailedToSendLog(MaxLogsPerBatch);
         }
 
         /// <summary>
         /// Validate that all logs removed
         /// </summary>
         [TestMethod]
-        public void ClearLogs()
+        public async Task TaskClearLogs()
         {
-            _channel.ShutdownAsync().RunNotAsync();
-            _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+            await _channel.ShutdownAsync();
+            await _channel.EnqueueAsync(new TestLog());
 
-            _channel.ClearAsync().RunNotAsync();
+            await _channel.ClearAsync();
             _channel.SetEnabled(true);
 
-            Assert.IsFalse(SendingLogOccurred(1));
+            VerifySendingLog(0);
         }
 
         /// <summary>
@@ -309,7 +298,7 @@ namespace Microsoft.AppCenter.Test.Channel
         /// Validate that StorageException is processing without exception
         /// </summary>
         [TestMethod]
-        public void ThrowStorageExceptionInDeleteLogsTime()
+        public async Task ThrowStorageExceptionInDeleteLogsTime()
         {
             var log = new TestLog();
             var storageException = new StorageException();
@@ -330,64 +319,125 @@ namespace Microsoft.AppCenter.Test.Channel
                 .Callback((string channelName, int limit, List<Log> logs) => logs.Add(log))
                 .Returns(() => Task.FromResult("test-batch-id"));
 
-            _channel = new Microsoft.AppCenter.Channel.Channel(ChannelName, 1, _batchTimeSpan, 1, _appSecret, _mockIngestion.Object, storage.Object);
+            var appSecret = Guid.NewGuid().ToString();
+            _channel = new Channel(ChannelName, 1, TimeSpan.FromSeconds(1), 1, appSecret, _mockIngestion.Object, storage.Object);
             SetupEventCallbacks();
 
             // Shutdown channel and store some log
-            _channel.ShutdownAsync().RunNotAsync();
-            _channel.EnqueueAsync(log).RunNotAsync();
+            await _channel.ShutdownAsync();
+            await _channel.EnqueueAsync(log);
 
             _channel.SetEnabled(true);
 
-            Assert.IsTrue(SentLogOccurred(1));
+           VerifySentLog(1);
 
             // Not throw any exception
         }
 
-        /// <summary>
-        /// Verify that when a recoverable http error occurs, ingestion stays open
-        /// </summary>
         [TestMethod]
-        public void IngestionNotClosedOnRecoverableHttpError()
+        public async Task MultiBatchTest()
         {
-            MakeIngestionCallsFail(new RecoverableIngestionException());
-            _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+            SetChannelWithTimeSpan(TimeSpan.Zero);
+            
+            var calls = new[] { new ServiceCall(), new ServiceCall(), new ServiceCall() };
+            var setup = _mockIngestion
+                .SetupSequence(ingestion => ingestion.Call(
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<IList<Log>>()));
+            foreach (var call in calls)
+            {
+                setup.Returns(call);
+            }
+            
+            // Send in separate batches
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
 
-            // wait for SendingLog event
-            _eventSemaphores[SendingLogSemaphoreIdx].Wait();
-            // wait up to 20 seconds for suspend to finish
-            bool disabled = WaitForChannelDisable(TimeSpan.FromSeconds(20));
-            Assert.IsTrue(disabled);
-            _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Never);
+            // Complete all
+            foreach (var call in calls)
+            {
+                call.SetResult("test");
+            }
+            VerifySentLog(3);
         }
 
         /// <summary>
-        /// Verify that if a non-recoverable http error occurs, ingestion is closed
+        /// Verify recoverable http error
         /// </summary>
         [TestMethod]
-        public void IngestionClosedOnNonRecoverableHttpError()
+        public async Task RecoverableHttpError()
         {
-            MakeIngestionCallsFail(new NonRecoverableIngestionException());
-            _channel.EnqueueAsync(new TestLog()).RunNotAsync();
+            SetChannelWithTimeSpan(TimeSpan.Zero);
 
-            // wait up to 20 seconds for suspend to finish
-            bool disabled = WaitForChannelDisable(TimeSpan.FromSeconds(20));
-            Assert.IsTrue(disabled);
+            // Enqueue some log and and do not complete it
+            var call = new ServiceCall();
+            _mockIngestion
+                .Setup(ingestion => ingestion.Call(
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<IList<Log>>()))
+                .Returns((string appSecret, Guid installId, IList<Log> logs) => call);
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
             
-            _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Once);
-            Assert.IsFalse(_channel.IsEnabled);
+            // Next one will fail
+            SetupIngestionCallFail(new RecoverableIngestionException());
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
+
+            // Wait up to 20 seconds for suspend to finish
+            VerifyChannelDisable(TimeSpan.FromSeconds(10));
+            _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Never);
+            VerifyFailedToSendLog(0);
+            Assert.IsFalse(call.IsCompleted);
+            Assert.IsFalse(call.IsCanceled);
+        }
+
+        /// <summary>
+        /// Verify non-recoverable http error
+        /// </summary>
+        [TestMethod]
+        public async Task NonRecoverableHttpError()
+        {
+            SetChannelWithTimeSpan(TimeSpan.Zero);
+
+            // Enqueue some log and and do not complete it
+            var call = new ServiceCall();
+            _mockIngestion
+                .Setup(ingestion => ingestion.Call(
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<IList<Log>>()))
+                .Returns((string appSecret, Guid installId, IList<Log> logs) => call);
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
+            
+            // Next one will fail
+            SetupIngestionCallFail(new NonRecoverableIngestionException());
+            await _channel.EnqueueAsync(new TestLog());
+            VerifySendingLog(1);
+
+            // Wait up to 20 seconds for suspend to finish
+            VerifyChannelDisable(TimeSpan.FromSeconds(10));
+            _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Never);
+            VerifyFailedToSendLog(2);
+
+            // The first call is canceled
+            await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => call.ToTask());
         }
 
         private void SetChannelWithTimeSpan(TimeSpan timeSpan)
         {
-            if (TestContext.TestName != "ThrowStorageExceptionInDeleteLogsTime")
-            {
-                _storage = new MockStorage();
-                _channel = new Microsoft.AppCenter.Channel.Channel(ChannelName, MaxLogsPerBatch, timeSpan, MaxParallelBatches,
-                    _appSecret, _mockIngestion.Object, _storage);
-                SetupEventCallbacks();
-            }
-            MakeIngestionCallsSucceed();
+            _storage = new MockStorage();
+            var appSecret = Guid.NewGuid().ToString();
+            _channel = new Channel(ChannelName, MaxLogsPerBatch, timeSpan, MaxParallelBatches,
+                appSecret, _mockIngestion.Object, _storage);
+            SetupEventCallbacks();
         }
 
         private void EnsureAllTasksAreFinishedInChannel()
@@ -401,7 +451,7 @@ namespace Microsoft.AppCenter.Test.Channel
             catch (ObjectDisposedException) { }
         }
 
-        private void MakeIngestionCallsFail(Exception exception)
+        private void SetupIngestionCallFail(Exception exception)
         {
             _mockIngestion
                 .Setup(ingestion => ingestion.Call(
@@ -416,7 +466,7 @@ namespace Microsoft.AppCenter.Test.Channel
                 });
         }
 
-        private void MakeIngestionCallsSucceed()
+        private void SetupIngestionCallSucceed(string result = "")
         {
             _mockIngestion
                 .Setup(ingestion => ingestion.Call(
@@ -426,20 +476,17 @@ namespace Microsoft.AppCenter.Test.Channel
                 .Returns((string appSecret, Guid installId, IList<Log> logs) =>
                 {
                     var call = new ServiceCall(appSecret, installId, logs);
-                    call.SetResult("");
+                    call.SetResult(result);
                     return call;
                 });
         }
 
         private void SetupEventCallbacks()
         {
-            foreach (var sem in _eventSemaphores)
+            _eventSemaphores = new List<SemaphoreSlim>
             {
-                if (sem.CurrentCount != 0)
-                {
-                    sem.Release(sem.CurrentCount);
-                }
-            }
+                new SemaphoreSlim(0), new SemaphoreSlim(0), new SemaphoreSlim(0), new SemaphoreSlim(0), new SemaphoreSlim(0)
+            };
             _channel.SendingLog += (sender, args) => { _eventSemaphores[SendingLogSemaphoreIdx].Release(); };
             _channel.SentLog += (sender, args) => { _eventSemaphores[SentLogSemaphoreIdx].Release(); };
             _channel.FailedToSendLog += (sender, args) => { _eventSemaphores[FailedToSendLogSemaphoreIdx].Release(); };
@@ -447,54 +494,47 @@ namespace Microsoft.AppCenter.Test.Channel
             _channel.FilteringLog += (sender, args) => { _eventSemaphores[FilteringLogSemaphoreIdx].Release(); };
         }
 
-        private bool FailedToSendLogOccurred(int numTimes, int waitTime = DefaultWaitTime)
-        {
-            return EventWithSemaphoreOccurred(_eventSemaphores[FailedToSendLogSemaphoreIdx], numTimes, waitTime);
-        }
+        private void VerifySendingLog(int expectedTimes) =>
+            Assert.AreEqual(expectedTimes, EventWithSemaphoreOccurred(_eventSemaphores[SendingLogSemaphoreIdx]),
+                $"Failed on verify {nameof(Channel.SendingLog)} event call times");
 
-        private bool EnqueuingLogOccurred(int numTimes, int waitTime = DefaultWaitTime)
-        {
-            return EventWithSemaphoreOccurred(_eventSemaphores[EnqueuingLogSemaphoreIdx], numTimes, waitTime);
-        }
+        private void VerifySentLog(int expectedTimes) =>
+            Assert.AreEqual(expectedTimes, EventWithSemaphoreOccurred(_eventSemaphores[SentLogSemaphoreIdx]),
+                $"Failed on verify {nameof(Channel.SentLog)} event call times");
 
-        private bool FilteringLogOccurred(int numTimes, int waitTime = DefaultWaitTime)
-        {
-            return EventWithSemaphoreOccurred(_eventSemaphores[FilteringLogSemaphoreIdx], numTimes, waitTime);
-        }
+        private void VerifyFailedToSendLog(int expectedTimes) =>
+            Assert.AreEqual(expectedTimes, EventWithSemaphoreOccurred(_eventSemaphores[FailedToSendLogSemaphoreIdx]),
+                $"Failed on verify {nameof(Channel.FailedToSendLog)} event call times");
 
-        private bool SentLogOccurred(int numTimes, int waitTime = DefaultWaitTime)
-        {
-            return EventWithSemaphoreOccurred(_eventSemaphores[SentLogSemaphoreIdx], numTimes, waitTime);
-        }
+        private void VerifyEnqueuingLog(int expectedTimes) =>
+            Assert.AreEqual(expectedTimes, EventWithSemaphoreOccurred(_eventSemaphores[EnqueuingLogSemaphoreIdx]),
+                $"Failed on verify {nameof(Channel.EnqueuingLog)} event call times");
 
-        private bool SendingLogOccurred(int numTimes, int waitTime = DefaultWaitTime)
-        {
-            return EventWithSemaphoreOccurred(_eventSemaphores[SendingLogSemaphoreIdx], numTimes, waitTime);
-        }
+        private void VerifyFilteringLog(int expectedTimes) =>
+            Assert.AreEqual(expectedTimes, EventWithSemaphoreOccurred(_eventSemaphores[FilteringLogSemaphoreIdx]),
+                $"Failed on verify {nameof(Channel.FilteringLog)} event call times");
 
-        private bool WaitForChannelDisable(TimeSpan timeout)
+        private void VerifyChannelDisable(TimeSpan timeout)
         {
             var task = Task.Run(async () =>
             {
                 while (_channel.IsEnabled)
                 {
-                    await Task.Delay(100);
+                    await Task.Delay(10);
                 }
             });
-
-            return task.Wait(timeout);
+            Assert.IsTrue(task.Wait(timeout));
         }
 
-        private static bool EventWithSemaphoreOccurred(SemaphoreSlim semaphore, int numTimes, int waitTime)
+        private static int EventWithSemaphoreOccurred(SemaphoreSlim semaphore)
         {
-            for (var i = 0; i < numTimes; ++i)
+            for (var i = 0;; ++i)
             {
-                if (!semaphore.Wait(waitTime))
+                if (!semaphore.Wait(i == 0 ? 1000 : 100))
                 {
-                    return false;
+                    return i;
                 }
             }
-            return true;
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
@@ -19,20 +19,30 @@ namespace Microsoft.AppCenter.Test.Channel
     public class ChannelTest
     {
         private AggregateException _unobservedTaskException;
+
         private Mock<IIngestion> _mockIngestion;
+
         private Channel _channel;
+
         private IStorage _storage;
 
         private const string ChannelName = "test";
+
         private const int MaxLogsPerBatch = 3;
+
         private const int MaxParallelBatches = 3;
 
         // Event semaphores for invokation verification
         private const int SendingLogSemaphoreIdx = 0;
+
         private const int SentLogSemaphoreIdx = 1;
+
         private const int FailedToSendLogSemaphoreIdx = 2;
+
         private const int EnqueuingLogSemaphoreIdx = 3;
+
         private const int FilteringLogSemaphoreIdx = 4;
+
         private List<SemaphoreSlim> _eventSemaphores;
 
         public ChannelTest()

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/MockStorage.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/MockStorage.cs
@@ -63,8 +63,11 @@ namespace Microsoft.AppCenter.Test.Storage
         {
             lock (this)
             {
+                var pending = _pending.SelectMany(i => i.Value).ToList();
                 var batchId = Guid.NewGuid().ToString();
-                var batch = this[channelName].Take(limit).ToList();
+                var batch = this[channelName]
+                    .Where(log => !pending.Contains(log))
+                    .Take(limit).ToList();
                 _pending.Add(batchId, batch);
                 logs?.Clear();
                 logs?.AddRange(batch);

--- a/Tests/Microsoft.AppCenter.Test.Windows/TaskExtension.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/TaskExtension.cs
@@ -8,55 +8,37 @@ namespace Microsoft.AppCenter.Test
     {
         public static T RunNotAsync<T>(this Task<T> @this)
         {
-            try
-            {
-                @this.Wait();
-            }
-            catch (AggregateException e)
-            {
-                throw e.InnerException;
-            }
-            return @this.Result;
+            return @this.GetAwaiter().GetResult();
         }
+
         public static void RunNotAsync(this Task @this)
         {
-            try
-            {
-                @this.Wait();
-            }
-            catch (AggregateException e)
-            {
-                throw e.InnerException;
-            }
+            @this.GetAwaiter().GetResult();
         }
 
         public static Task GetCompletedTask()
         {
-            var completedTask = Task.Delay(0);
-            completedTask.Wait();
-            return completedTask;
+            return Task.FromResult(false);
         }
 
         public static Task GetFaultedTask(Exception e)
         {
-            Task task = null;
+            var task = Task.Factory.StartNew(() => throw e);
             try
             {
-                task = Task.Factory.StartNew(() => { throw e; });
                 task.Wait();
             }
-            catch (Exception)
+            catch
             {
-
+                // ignored
             }
+
             return task;
         }
 
         public static Task<T> GetCompletedTask<T>(T retVal)
         {
-            var completedTask = Task<T>.Factory.StartNew(() => retVal);
-            completedTask.Wait();
-            return completedTask;
+            return Task.FromResult(retVal);
         }
 
         public static Task<T> GetFaultedTask<T>(Exception exception)
@@ -66,9 +48,9 @@ namespace Microsoft.AppCenter.Test
             {
                 task.Wait();
             }
-            catch (Exception)
+            catch
             {
-
+                // ignored
             }
             return task;
         }


### PR DESCRIPTION
- Do not close current calls from other channels on suspending;
- Do not duplicate `SendingLog`/`FailedToSendLog` events on sending error;
- Add more verbose logs;
- Readable messages on verify event call count in tests;
- Verify if an event occurred more times than expected;

Should be retargeted to develop after merge #643