### PR TITLE
Catch all exceptions from (de)serialize exceptions

### DIFF
--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml
@@ -20,6 +20,9 @@
             <ViewCell Tapped="TestException">
                 <Button Text="Generate Test Exception" InputTransparent="true" Clicked="TestException" />
             </ViewCell>
+            <ViewCell Tapped="NonSerializableException">
+                <Button Text="Generate non serializable Exception" InputTransparent="true" Clicked="NonSerializableException" />
+            </ViewCell>
             <ViewCell Tapped="DivideByZero">
                 <Button Text="Divide 42 by 0" InputTransparent="true" Clicked="DivideByZero" />
             </ViewCell>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -11,6 +11,10 @@ namespace Contoso.Forms.Puppet
 {
     using XamarinDevice = Xamarin.Forms.Device;
 
+    public class NonSerializableException : Exception
+    {
+    }
+
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class CrashesContentPage
     {
@@ -127,6 +131,11 @@ namespace Contoso.Forms.Puppet
         void TestException(object sender, EventArgs e)
         {
             HandleOrThrow(() => Crashes.GenerateTestCrash());
+        }
+
+        void NonSerializableException(object sender, EventArgs e)
+        {
+            HandleOrThrow(() => throw new NonSerializableException());
         }
 
         void DivideByZero(object sender, EventArgs e)

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
@@ -8,10 +8,6 @@ namespace Microsoft.AppCenter.Crashes
     {
         internal static byte[] SerializeException(Exception exception)
         {
-            if (exception == null)
-            {
-                return null;
-            }
             if (!exception.GetType().IsSerializable)
             {
                 AppCenterLog.Warn(Crashes.LogTag, $"Cannot serialize {exception.GetType().FullName} exception for client side inspection. " +

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
@@ -8,6 +8,17 @@ namespace Microsoft.AppCenter.Crashes
     {
         internal static byte[] SerializeException(Exception exception)
         {
+            if (exception == null)
+            {
+                return null;
+            }
+            if (!exception.GetType().IsSerializable)
+            {
+                AppCenterLog.Warn(Crashes.LogTag, $"Cannot serialize {exception.GetType().FullName} exception for client side inspection. " +
+                                  "If you want to have access to the exception in the callbacks, please add a Serializable attribute " +
+                                  "and a deserialization constructor to the exception class.");
+                return null;
+            }
             try
             {
                 using (var memoryStream = new MemoryStream())
@@ -19,7 +30,7 @@ namespace Microsoft.AppCenter.Crashes
             }
             catch (Exception e)
             {
-                AppCenterLog.Warn(Crashes.LogTag, "Failed to serialize exception for client side inspection", e);
+                AppCenterLog.Warn(Crashes.LogTag, "Failed to serialize exception for client side inspection.", e);
             }
             return null;
         }
@@ -36,7 +47,7 @@ namespace Microsoft.AppCenter.Crashes
             }
             catch (Exception e)
             {
-                AppCenterLog.Warn(Crashes.LogTag, "Failed to deserialize exception for client side inspection", e);
+                AppCenterLog.Warn(Crashes.LogTag, "Failed to deserialize exception for client side inspection.", e);
             }
             return null;
         }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Microsoft.AppCenter.Crashes
@@ -9,41 +8,37 @@ namespace Microsoft.AppCenter.Crashes
     {
         internal static byte[] SerializeException(Exception exception)
         {
-            var ms = new MemoryStream();
-            var formatter = new BinaryFormatter();
-
             try
             {
-                formatter.Serialize(ms, exception);
+                using (var memoryStream = new MemoryStream())
+                {
+                    var formatter = new BinaryFormatter();
+                    formatter.Serialize(memoryStream, exception);
+                    return memoryStream.ToArray();
+                }
             }
-            catch (SerializationException e)
+            catch (Exception e)
             {
                 AppCenterLog.Warn(Crashes.LogTag, "Failed to serialize exception for client side inspection", e);
-                ms = new MemoryStream();
-                formatter.Serialize(ms, e);
             }
-
-            return ms.ToArray();
+            return null;
         }
 
         internal static Exception DeserializeException(byte[] exceptionBytes)
         {
-            var ms = new MemoryStream(exceptionBytes);
-            var formatter = new BinaryFormatter();
-
-            Exception deserializedException;
-
             try
             {
-               deserializedException = formatter.Deserialize(ms) as Exception;
+                using (var memoryStream = new MemoryStream(exceptionBytes))
+                {
+                    var formatter = new BinaryFormatter();
+                    return formatter.Deserialize(memoryStream) as Exception;
+                }
             }
-            catch(SerializationException e)
+            catch (Exception e)
             {
                 AppCenterLog.Warn(Crashes.LogTag, "Failed to deserialize exception for client side inspection", e);
-                deserializedException = e;
             }
-
-            return deserializedException;
+            return null;
         }
     }
 }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -102,9 +102,8 @@ namespace Microsoft.AppCenter.Crashes
             Exception systemException = e.ExceptionObject as Exception;
             AppCenterLog.Error(LogTag, "Unhandled Exception:", systemException);
             MSException exception = GenerateiOSException(systemException, true);
-            byte[] exceptionBytes = CrashesUtils.SerializeException(systemException);
+            byte[] exceptionBytes = CrashesUtils.SerializeException(systemException) ?? new byte[0];
             NSData wrapperExceptionData = NSData.FromArray(exceptionBytes);
-
             MSWrapperException wrapperException = new MSWrapperException
             {
                 Exception = exception,

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/ErrorReport.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/ErrorReport.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AppCenter.Crashes
                                              (uint)msReport.AppProcessIdentifier);
 
             MSWrapperException wrapperException = MSWrapperExceptionManager.LoadWrapperExceptionWithUUID(msReport.IncidentIdentifier);
-            if (wrapperException != null && wrapperException.ExceptionData != null)
+            if (wrapperException != null && wrapperException.ExceptionData != null && wrapperException.ExceptionData.Length > 0)
             {
                 Exception = CrashesUtils.DeserializeException(wrapperException.ExceptionData.ToArray());
             }


### PR DESCRIPTION
- Catch all exceptions (there is crash report caused by SDK with `System.Reflection.TargetInvocationException`);
- Do not serialize serialization exception;
- Do not assign deserialization exception as original one;
- Dispose `MemoryStream`s