### PR TITLE
Owenniblock: fix/stabilize uitests

### DIFF
--- a/Tests/Contoso.Forms.Test/Module Pages/CrashesPage.xaml.cs
+++ b/Tests/Contoso.Forms.Test/Module Pages/CrashesPage.xaml.cs
@@ -9,6 +9,8 @@ namespace Contoso.Forms.Test
 {
     public partial class CrashesPage : ContentPage
     {
+        private const int BeforeCrashSleepTime = 500;
+
         public CrashesPage()
         {
             InitializeComponent();
@@ -21,7 +23,7 @@ namespace Contoso.Forms.Test
 
         void DivideByZeroCrash(object sender, System.EventArgs e)
         {
-            Task.Delay(500).Wait();
+            Task.Delay(BeforeCrashSleepTime).Wait();
 
 #pragma warning disable CS0219
             int x = (42 / int.Parse("0"));
@@ -35,7 +37,7 @@ namespace Contoso.Forms.Test
 
         void CrashWithInvalidOperation(object sender, EventArgs e)
         {
-            Task.Delay(500).Wait();
+            Task.Delay(BeforeCrashSleepTime).Wait();
 
             string[] strings = { "A", "B", "C" };
 #pragma warning disable CS0219
@@ -57,7 +59,7 @@ namespace Contoso.Forms.Test
 
         private void CrashWithAggregateException(object sender, EventArgs e)
         {
-            Task.Delay(500).Wait();
+            Task.Delay(BeforeCrashSleepTime).Wait();
 
             throw PrepareException();
         }
@@ -100,7 +102,7 @@ namespace Contoso.Forms.Test
 
         public async void CrashAsync(object sender, EventArgs e)
         {
-            Task.Delay(500).Wait();
+            Task.Delay(BeforeCrashSleepTime).Wait();
 
             await FakeService.DoStuffInBackground().ConfigureAwait(false);
         }

--- a/Tests/Contoso.Forms.Test/Module Pages/CrashesPage.xaml.cs
+++ b/Tests/Contoso.Forms.Test/Module Pages/CrashesPage.xaml.cs
@@ -21,6 +21,8 @@ namespace Contoso.Forms.Test
 
         void DivideByZeroCrash(object sender, System.EventArgs e)
         {
+            Task.Delay(500).Wait();
+
 #pragma warning disable CS0219
             int x = (42 / int.Parse("0"));
 #pragma warning restore CS0219
@@ -33,6 +35,8 @@ namespace Contoso.Forms.Test
 
         void CrashWithInvalidOperation(object sender, EventArgs e)
         {
+            Task.Delay(500).Wait();
+
             string[] strings = { "A", "B", "C" };
 #pragma warning disable CS0219
             string s = strings.First((arg) => { return arg == "6"; });
@@ -53,6 +57,8 @@ namespace Contoso.Forms.Test
 
         private void CrashWithAggregateException(object sender, EventArgs e)
         {
+            Task.Delay(500).Wait();
+
             throw PrepareException();
         }
 
@@ -94,6 +100,8 @@ namespace Contoso.Forms.Test
 
         public async void CrashAsync(object sender, EventArgs e)
         {
+            Task.Delay(500).Wait();
+
             await FakeService.DoStuffInBackground().ConfigureAwait(false);
         }
 

--- a/Tests/UITests/Contoso.Forms.Test.UITests.csproj
+++ b/Tests/UITests/Contoso.Forms.Test.UITests.csproj
@@ -30,7 +30,7 @@
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.UITest">
-      <HintPath>..\..\packages\Xamarin.UITest.2.2.1\lib\net45\Xamarin.UITest.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.UITest.2.2.4.1779-dev\lib\net45\Xamarin.UITest.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/UITests/CorePageHelper.cs
+++ b/Tests/UITests/CorePageHelper.cs
@@ -13,37 +13,23 @@ namespace Contoso.Forms.Test.UITests
             get
             {
                 string guidString = WaitForLabelToSayAnything(TestStrings.InstallIdLabel);
-                try
-                {
-                    return Guid.Parse(guidString);
-                }
-                catch (FormatException)
-                {
-                    return null;
-                }
+                return Guid.Parse(guidString);
             }
         }
 
         static string WaitForLabelToSayAnything(string labelName)
         {
-            try
+            string text = "";
+            app.WaitFor(() =>
             {
-                string text = "";
-                app.WaitFor(() =>
-                {
-                    AppResult[] results = app.Query(labelName);
-                    if (results.Length < 1)
-                        return false;
-                    AppResult label = results[0];
-                    text = label.Text != "" ? label.Text : text;
-                    return label.Text != "";
-                }, timeout: TimeSpan.FromSeconds(5));
-                return text;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+                AppResult[] results = app.Query(labelName);
+                if (results.Length < 1)
+                    return false;
+                AppResult label = results[0];
+                text = string.IsNullOrEmpty(label.Text) ? text : label.Text;
+                return !string.IsNullOrEmpty(label.Text);
+            }, timeout: TimeSpan.FromSeconds(5));
+            return text;
         }
     }
 }

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -72,6 +72,7 @@ namespace Contoso.Forms.Test.UITests
         public void TestServiceStatePersistence()
         {
             ServiceStateHelper.app = app;
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
 
             /* Make sure Crashes enabled state is persistent */
@@ -120,9 +121,12 @@ namespace Contoso.Forms.Test.UITests
         public void SendEventWithProperties()
         {
             app.Tap(TestStrings.GoToAnalyticsPageButton);
+            app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
+
             int numProperties = 5;
             SendEvent(numProperties);
             app.Tap(TestStrings.GoToAnalyticsResultsPageButton);
+            app.WaitForElement(TestStrings.EventPropertiesLabel);
 
             /* Verify that the event was sent properly */
             AnalyticsResultsHelper.app = app;
@@ -137,9 +141,12 @@ namespace Contoso.Forms.Test.UITests
         public void SendEventWithNoProperties()
         {
             app.Tap(TestStrings.GoToAnalyticsPageButton);
+            app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
+
             int numProperties = 0;
             SendEvent(numProperties);
             app.Tap(TestStrings.GoToAnalyticsResultsPageButton);
+            app.WaitForElement(TestStrings.EventPropertiesLabel);
 
             /* Verify that the event was sent properly */
             AnalyticsResultsHelper.app = app;
@@ -160,9 +167,12 @@ namespace Contoso.Forms.Test.UITests
             app.Tap(TestStrings.DismissButton);
 
             app.Tap(TestStrings.GoToAnalyticsPageButton);
+            app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
+
             int numProperties = 1;
             SendEvent(numProperties);
             app.Tap(TestStrings.GoToAnalyticsResultsPageButton);
+            app.WaitForElement(TestStrings.EventPropertiesLabel);
 
             /* Verify that the event was not sent */
             AnalyticsResultsHelper.app = app;

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -139,7 +139,6 @@ namespace Contoso.Forms.Test.UITests
             app = AppInitializer.StartAppNoClear(platform);
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
-            app.Screenshot("Go To Toggle Page Pressed...");
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -70,7 +70,7 @@ namespace Contoso.Forms.Test.UITests
         }
 
         [Test]
-        public void TestServiceStatePersistence()
+        public void TestServiceStatePersistenceCrashes()
         {
             app.Screenshot("App Launched - Ready for tests");
             ServiceStateHelper.app = app;
@@ -91,7 +91,19 @@ namespace Contoso.Forms.Test.UITests
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
             Assert.IsTrue(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
-            app.Screenshot("Crashes enabled");
+            app.Screenshot("Crashes persistent");
+
+            /* Reset services to enabled */
+            ServiceStateHelper.AppCenterEnabled = true;
+        }
+
+        [Test]
+        public void TestServiceStatePersistenceAnalytics()
+        {
+            app.Screenshot("App Launched - Ready for tests");
+            ServiceStateHelper.app = app;
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
+            app.Tap(TestStrings.GoToTogglePageButton);
 
             /* Make sure Analytics enabled state is persistent */
             ServiceStateHelper.AppCenterEnabled = true;
@@ -104,7 +116,19 @@ namespace Contoso.Forms.Test.UITests
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsTrue(ServiceStateHelper.CrashesEnabled);
-            app.Screenshot("Analytics enabled");
+            app.Screenshot("Analytics persistent");
+
+            /* Reset services to enabled */
+            ServiceStateHelper.AppCenterEnabled = true;
+        }
+
+        [Test]
+        public void TestServiceStatePersistenceAppCenter()
+        {
+            app.Screenshot("App Launched - Ready for tests");
+            ServiceStateHelper.app = app;
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
+            app.Tap(TestStrings.GoToTogglePageButton);
 
             /* Make sure AppCenter enabled state is persistent */
             ServiceStateHelper.AppCenterEnabled = false;
@@ -115,15 +139,15 @@ namespace Contoso.Forms.Test.UITests
             app = AppInitializer.StartAppNoClear(platform);
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
+            app.Screenshot("Go To Toggle Page Pressed...");
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
-            app.Screenshot("AppCenter enabled");
+            app.Screenshot("AppCenter persistent");
 
             /* Reset services to enabled */
             ServiceStateHelper.AppCenterEnabled = true;
         }
-
 
         [Test]
         public void SendEventWithProperties()

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -13,6 +13,9 @@ namespace Contoso.Forms.Test.UITests
         IApp app;
         Platform platform;
 
+        private const int AfterCrashSleepTime = 2000;
+        private const int LongStabilizationSleepTime = 10000;
+
         public Tests(Platform platform)
         {
             this.platform = platform;
@@ -27,6 +30,8 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void InstallIdIsCorrectFormat()
         {
+            app.Screenshot("InstallIdIsCorrectFormat - Ready for tests");
+
             CorePageHelper.app = app;
             app.Tap(TestStrings.GoToCorePageButton);
             var id = CorePageHelper.InstallId;
@@ -36,6 +41,8 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void TestEnablingAndDisablingServices()
         {
+            app.Screenshot("TestEnablingAndDisablingServices - Ready for tests");
+
             ServiceStateHelper.app = app;
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
@@ -72,7 +79,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void TestServiceStatePersistenceCrashes()
         {
-            app.Screenshot("App Launched - Ready for tests");
+            app.Screenshot("TestServiceStatePersistenceCrashes - Ready for tests");
             ServiceStateHelper.app = app;
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
@@ -81,13 +88,16 @@ namespace Contoso.Forms.Test.UITests
             ServiceStateHelper.AppCenterEnabled = true;
             ServiceStateHelper.CrashesEnabled = false;
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
-            //There seems to be some sort of timing issue here.
-            //   without the Thread.Sleep - this code fails although I see that the method called is Async (with a Wait)
-            //   so I think this deserves further investigation. I've added a terribly long wait to get the tests green.
-            Thread.Sleep(10000);
+
+            // There seems to be some sort of timing issue here.
+            // without the Thread.Sleep - this code fails although I see that the method called is Async (with a Wait)
+            // so I think this deserves further investigation. I've added a terribly long wait to get the tests green.
+            Thread.Sleep(LongStabilizationSleepTime);
             app = AppInitializer.StartAppNoClear(platform);
+            Thread.Sleep(LongStabilizationSleepTime);
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
+            Thread.Sleep(LongStabilizationSleepTime);
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
             Assert.IsTrue(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
@@ -100,7 +110,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void TestServiceStatePersistenceAnalytics()
         {
-            app.Screenshot("App Launched - Ready for tests");
+            app.Screenshot("TestServiceStatePersistenceAnalytics - Ready for tests");
             ServiceStateHelper.app = app;
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
@@ -109,10 +119,12 @@ namespace Contoso.Forms.Test.UITests
             ServiceStateHelper.AppCenterEnabled = true;
             ServiceStateHelper.AnalyticsEnabled = false;
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
-            Thread.Sleep(10000);
+            Thread.Sleep(LongStabilizationSleepTime);
+
             app = AppInitializer.StartAppNoClear(platform);
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
+            Thread.Sleep(LongStabilizationSleepTime);
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsTrue(ServiceStateHelper.CrashesEnabled);
@@ -125,20 +137,27 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void TestServiceStatePersistenceAppCenter()
         {
-            app.Screenshot("App Launched - Ready for tests");
+            app.Screenshot("TestServiceStatePersistenceAppCenter - Ready for tests");
             ServiceStateHelper.app = app;
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
 
             /* Make sure AppCenter enabled state is persistent */
+            ServiceStateHelper.AppCenterEnabled = true;
             ServiceStateHelper.AppCenterEnabled = false;
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
-            Thread.Sleep(10000);
+            Thread.Sleep(LongStabilizationSleepTime);
+
+            app.Screenshot("TestServiceStatePersistenceAppCenter - Before restart");
+
             app = AppInitializer.StartAppNoClear(platform);
+            Thread.Sleep(LongStabilizationSleepTime);
+
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
+            Thread.Sleep(LongStabilizationSleepTime);
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
@@ -151,6 +170,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void SendEventWithProperties()
         {
+            app.Screenshot("SendEventWithProperties - Ready for tests");
             app.WaitForElement(TestStrings.GoToAnalyticsPageButton);
             app.Tap(TestStrings.GoToAnalyticsPageButton);
             app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
@@ -172,6 +192,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void SendEventWithNoProperties()
         {
+            app.Screenshot("SendEventWithNoProperties - Ready for tests");
             app.WaitForElement(TestStrings.GoToAnalyticsPageButton);
             app.Tap(TestStrings.GoToAnalyticsPageButton);
             app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
@@ -193,6 +214,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void SendEventWithAnalyticsDisabled()
         {
+            app.Screenshot("SendEventWithAnalyticsDisabled - Ready for tests");
             /* Disable Analytics */
             ServiceStateHelper.app = app;
             app.WaitForElement(TestStrings.GoToTogglePageButton);
@@ -220,13 +242,14 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void InvalidOperation()
         {
+            app.Screenshot("InvalidOperation - Ready for tests");
             /* Crash the application with an invalid operation exception and then restart */
             app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
             app.WaitForElement(TestStrings.CrashWithInvalidOperationButton);
             app.Tap(TestStrings.CrashWithInvalidOperationButton);
 
-            Thread.Sleep(2000);
+            Thread.Sleep(AfterCrashSleepTime);
 
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
@@ -237,13 +260,14 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void AggregateException()
         {
+            app.Screenshot("AggregateException - Ready for tests");
             /* Crash the application with an aggregate exception and then restart */
             app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
             app.WaitForElement(TestStrings.CrashWithAggregateExceptionButton);
             app.Tap(TestStrings.CrashWithAggregateExceptionButton);
 
-            Thread.Sleep(2000);
+            Thread.Sleep(AfterCrashSleepTime);
 
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
@@ -254,13 +278,14 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void DivideByZero()
         {
+            app.Screenshot("DivideByZero - Ready for tests");
             /* Crash the application with a divide by zero exception and then restart */
             app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
             app.WaitForElement(TestStrings.DivideByZeroCrashButton);
             app.Tap(TestStrings.DivideByZeroCrashButton);
 
-            Thread.Sleep(2000);
+            Thread.Sleep(AfterCrashSleepTime);
 
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
@@ -271,13 +296,14 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void AsyncTaskException()
         {
+            app.Screenshot("AsyncTaskException - Ready for tests");
             /* Crash the application inside an asynchronous task and then restart */
             app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
             app.WaitForElement(TestStrings.CrashInsideAsyncTaskButton);
             app.Tap(TestStrings.CrashInsideAsyncTaskButton);
 
-            Thread.Sleep(2000);
+            Thread.Sleep(AfterCrashSleepTime);
 
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
@@ -290,6 +316,7 @@ namespace Contoso.Forms.Test.UITests
         /* Verify that a crash has been triggered and handled correctly */
         public void TestSuccessfulCrash()
         {
+            app.Screenshot("TestSuccessfulCrash - Ready for tests");
             app = AppInitializer.StartAppNoClear(platform);
             app.WaitForElement(TestStrings.GoToCrashResultsPageButton);
             app.Tap(TestStrings.GoToCrashResultsPageButton);

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -2,6 +2,7 @@
 using Xamarin.UITest;
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Contoso.Forms.Test.UITests
 {
@@ -77,6 +78,10 @@ namespace Contoso.Forms.Test.UITests
             ServiceStateHelper.AppCenterEnabled = true;
             ServiceStateHelper.CrashesEnabled = false;
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
+            //There seems to be some sort of timing issue here.
+            //   without the Thread.Sleep - this code fails although I see that the method called is Async (with a Wait)
+            //   so I think this deserves further investigation. I've added a terribly long wait to get the tests green.
+            Thread.Sleep(10000);
             app = AppInitializer.StartAppNoClear(platform);
             app.Tap(TestStrings.GoToTogglePageButton);
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
@@ -87,6 +92,7 @@ namespace Contoso.Forms.Test.UITests
             ServiceStateHelper.AppCenterEnabled = true;
             ServiceStateHelper.AnalyticsEnabled = false;
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
+            Thread.Sleep(10000);
             app = AppInitializer.StartAppNoClear(platform);
             app.Tap(TestStrings.GoToTogglePageButton);
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
@@ -98,6 +104,7 @@ namespace Contoso.Forms.Test.UITests
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
+            Thread.Sleep(10000);
             app = AppInitializer.StartAppNoClear(platform);
             app.Tap(TestStrings.GoToTogglePageButton);
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -37,6 +37,7 @@ namespace Contoso.Forms.Test.UITests
         public void TestEnablingAndDisablingServices()
         {
             ServiceStateHelper.app = app;
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
 
             /* Test setting enabling all services */
@@ -71,6 +72,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void TestServiceStatePersistence()
         {
+            app.Screenshot("App Launched - Ready for tests");
             ServiceStateHelper.app = app;
             app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
@@ -84,10 +86,12 @@ namespace Contoso.Forms.Test.UITests
             //   so I think this deserves further investigation. I've added a terribly long wait to get the tests green.
             Thread.Sleep(10000);
             app = AppInitializer.StartAppNoClear(platform);
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
             Assert.IsTrue(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
+            app.Screenshot("Crashes enabled");
 
             /* Make sure Analytics enabled state is persistent */
             ServiceStateHelper.AppCenterEnabled = true;
@@ -95,10 +99,12 @@ namespace Contoso.Forms.Test.UITests
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Thread.Sleep(10000);
             app = AppInitializer.StartAppNoClear(platform);
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
             Assert.IsTrue(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsTrue(ServiceStateHelper.CrashesEnabled);
+            app.Screenshot("Analytics enabled");
 
             /* Make sure AppCenter enabled state is persistent */
             ServiceStateHelper.AppCenterEnabled = false;
@@ -107,10 +113,12 @@ namespace Contoso.Forms.Test.UITests
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Thread.Sleep(10000);
             app = AppInitializer.StartAppNoClear(platform);
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
             Assert.IsFalse(ServiceStateHelper.AppCenterEnabled);
             Assert.IsFalse(ServiceStateHelper.AnalyticsEnabled);
             Assert.IsFalse(ServiceStateHelper.CrashesEnabled);
+            app.Screenshot("AppCenter enabled");
 
             /* Reset services to enabled */
             ServiceStateHelper.AppCenterEnabled = true;
@@ -120,6 +128,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void SendEventWithProperties()
         {
+            app.WaitForElement(TestStrings.GoToAnalyticsPageButton);
             app.Tap(TestStrings.GoToAnalyticsPageButton);
             app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
 
@@ -140,6 +149,7 @@ namespace Contoso.Forms.Test.UITests
         [Test]
         public void SendEventWithNoProperties()
         {
+            app.WaitForElement(TestStrings.GoToAnalyticsPageButton);
             app.Tap(TestStrings.GoToAnalyticsPageButton);
             app.WaitForElement(TestStrings.GoToAnalyticsResultsPageButton);
 
@@ -162,6 +172,7 @@ namespace Contoso.Forms.Test.UITests
         {
             /* Disable Analytics */
             ServiceStateHelper.app = app;
+            app.WaitForElement(TestStrings.GoToTogglePageButton);
             app.Tap(TestStrings.GoToTogglePageButton);
             ServiceStateHelper.AnalyticsEnabled = false;
             app.Tap(TestStrings.DismissButton);
@@ -187,8 +198,13 @@ namespace Contoso.Forms.Test.UITests
         public void InvalidOperation()
         {
             /* Crash the application with an invalid operation exception and then restart */
+            app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
+            app.WaitForElement(TestStrings.CrashWithInvalidOperationButton);
             app.Tap(TestStrings.CrashWithInvalidOperationButton);
+
+            Thread.Sleep(2000);
+
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
             Assert.IsTrue(LastSessionErrorReportHelper.VerifyExceptionType(typeof(InvalidOperationException).Name));
@@ -199,8 +215,13 @@ namespace Contoso.Forms.Test.UITests
         public void AggregateException()
         {
             /* Crash the application with an aggregate exception and then restart */
+            app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
+            app.WaitForElement(TestStrings.CrashWithAggregateExceptionButton);
             app.Tap(TestStrings.CrashWithAggregateExceptionButton);
+
+            Thread.Sleep(2000);
+
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
             Assert.IsTrue(LastSessionErrorReportHelper.VerifyExceptionType(typeof(AggregateException).Name));
@@ -211,8 +232,13 @@ namespace Contoso.Forms.Test.UITests
         public void DivideByZero()
         {
             /* Crash the application with a divide by zero exception and then restart */
+            app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
+            app.WaitForElement(TestStrings.DivideByZeroCrashButton);
             app.Tap(TestStrings.DivideByZeroCrashButton);
+
+            Thread.Sleep(2000);
+
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
             Assert.IsTrue(LastSessionErrorReportHelper.VerifyExceptionType(typeof(DivideByZeroException).Name));
@@ -223,8 +249,13 @@ namespace Contoso.Forms.Test.UITests
         public void AsyncTaskException()
         {
             /* Crash the application inside an asynchronous task and then restart */
+            app.WaitForElement(TestStrings.GoToCrashesPageButton);
             app.Tap(TestStrings.GoToCrashesPageButton);
+            app.WaitForElement(TestStrings.CrashInsideAsyncTaskButton);
             app.Tap(TestStrings.CrashInsideAsyncTaskButton);
+
+            Thread.Sleep(2000);
+
             TestSuccessfulCrash();
             LastSessionErrorReportHelper.app = app;
             Assert.IsTrue(LastSessionErrorReportHelper.VerifyExceptionType(typeof(IOException).Name));
@@ -237,6 +268,7 @@ namespace Contoso.Forms.Test.UITests
         public void TestSuccessfulCrash()
         {
             app = AppInitializer.StartAppNoClear(platform);
+            app.WaitForElement(TestStrings.GoToCrashResultsPageButton);
             app.Tap(TestStrings.GoToCrashResultsPageButton);
 
             /* Ensure that the callbacks were properly called */

--- a/Tests/UITests/packages.config
+++ b/Tests/UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.2.4.1779-dev" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.2.5" targetFramework="net45" />
 </packages>

--- a/Tests/UITests/packages.config
+++ b/Tests/UITests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="2.2.1" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="2.2.4.1779-dev" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
From the original PR:

### Motivation
The UITests are failing intermittently - this work attempts to stabilise the tests.

### Notes
I'm having trouble getting the `TestServiceStatePersistence` tests to go green on all Android devices. I suspect this might be an issue with the Calabash Android Server (I've created a bug on our side for investigation).

iOS tests are consistently green on a local device and in App Center.

Android tests (except the above) are consistently green on a local device and in App Center.

If you let me know your App Center user name - I'll add you as a collaborator so you can see the app test runs and the device selection. It's possible that I've been lucky with my device selection but it seems to cover a relatively broad cross-section.

Also - I have flagged up for investigation an issue where the Toggle page seems to continue before the data is saved (and then when the app restarts it fails to complete the save). I've found that if I add a long wait in then it works correctly so maybe an async process isn't waiting for completion correctly (definitely worth checking this out). For now the long wait will keep the tests green unless there's additional issues.