### PR TITLE
Fix UI tests

### DIFF
--- a/Tests/Contoso.Forms.Test.Strings/Strings.cs
+++ b/Tests/Contoso.Forms.Test.Strings/Strings.cs
@@ -107,7 +107,6 @@
 
         /* AnalyticsResultsPage */
         /* Automation Ids */
-        public static readonly string EventPropertiesLabel = "EventPropertiesLabel";
         public static readonly string EventNameLabel = "EventNameLabel";
         public static readonly string DidSentEventLabel = "DidSendEventLabel";
         public static readonly string DidFailedToSendEventLabel = "DidFailToSendEventLabel";

--- a/Tests/Contoso.Forms.Test/Contoso.Forms.Test.csproj
+++ b/Tests/Contoso.Forms.Test/Contoso.Forms.Test.csproj
@@ -92,15 +92,6 @@
     <Folder Include="Module Pages\CrashResults Pages\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AppCenter">
-      <HintPath>..\..\packages\Microsoft.AppCenter.1.6.1-r0008-b295835\lib\portable-net45+win8+wpa81+wp8\Microsoft.AppCenter.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Analytics">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.6.1-r0008-b295835\lib\portable-net45+win8+wpa81+wp8\Microsoft.AppCenter.Analytics.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Crashes">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.6.1-r0008-b295835\lib\portable-net45+win8+wpa81+wp8\Microsoft.AppCenter.Crashes.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Forms.Core">
       <HintPath>..\..\packages\Xamarin.Forms.3.1.0.697729\lib\netstandard1.0\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
@@ -109,6 +100,15 @@
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
       <HintPath>..\..\packages\Xamarin.Forms.3.1.0.697729\lib\netstandard1.0\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter">
+      <HintPath>..\..\packages\Microsoft.AppCenter.1.10.1-r0002-2d8d46d\lib\portable-net45+win8+wpa81+wp8\Microsoft.AppCenter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Crashes">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.10.1-r0002-2d8d46d\lib\portable-net45+win8+wpa81+wp8\Microsoft.AppCenter.Crashes.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.10.1-r0002-2d8d46d\lib\portable-net45+win8+wpa81+wp8\Microsoft.AppCenter.Analytics.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Contoso.Forms.Test/EventData.cs
+++ b/Tests/Contoso.Forms.Test/EventData.cs
@@ -1,10 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace Contoso.Forms.Test
+﻿namespace Contoso.Forms.Test
 {
     public class EventData
     {
         public string Name;
-        public Dictionary<string, string> Properties;
     }
 }

--- a/Tests/Contoso.Forms.Test/Module Pages/AnalyticsResultsPage.xaml
+++ b/Tests/Contoso.Forms.Test/Module Pages/AnalyticsResultsPage.xaml
@@ -1,12 +1,9 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:local="clr-namespace:Contoso.Forms.Test;assembly=Contoso.Forms.Test" x:Class="Contoso.Forms.Test.AnalyticsResultsPage">
     <TableView Intent="Form">
         <TableSection>
             <ViewCell>
                 <Label x:Name="EventNameLabel" AutomationId="{x:Static local:TestStrings.EventNameLabel}" />
-            </ViewCell>
-            <ViewCell>
-                <Label x:Name="EventPropertiesLabel" AutomationId="{x:Static local:TestStrings.EventPropertiesLabel}" />
             </ViewCell>
             <ViewCell>
                 <Label x:Name="DidSentEventLabel" AutomationId="{x:Static local:TestStrings.DidSentEventLabel}" />

--- a/Tests/Contoso.Forms.Test/Module Pages/AnalyticsResultsPage.xaml.cs
+++ b/Tests/Contoso.Forms.Test/Module Pages/AnalyticsResultsPage.xaml.cs
@@ -20,11 +20,6 @@ namespace Contoso.Forms.Test
                         EventNameLabel.Text = data.Name;
                     }
 
-                    if (EventPropertiesLabel != null)
-                    {
-                        EventPropertiesLabel.Text = data.Properties == null ? "0" : data.Properties.Values.Count.ToString();
-                    }
-
                     if (DidSendingEventLabel != null)
                     {
                         DidSendingEventLabel.Text = TestStrings.DidSendingEventText;
@@ -67,7 +62,6 @@ namespace Contoso.Forms.Test
         void ResetPage(object sender, EventArgs e)
         {
             EventNameLabel.Text = "";
-            EventPropertiesLabel.Text = "";
             DidSentEventLabel.Text = "";
             DidSendingEventLabel.Text = "";
             DidFailedToSendEventLabel.Text = "";

--- a/Tests/Contoso.Forms.Test/packages.config
+++ b/Tests/Contoso.Forms.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AppCenter" version="1.6.1-r0008-b295835" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Microsoft.AppCenter.Analytics" version="1.6.1-r0008-b295835" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="Microsoft.AppCenter.Crashes" version="1.6.1-r0008-b295835" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.AppCenter" version="1.10.1-r0002-2d8d46d" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.AppCenter.Analytics" version="1.10.1-r0002-2d8d46d" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.AppCenter.Crashes" version="1.10.1-r0002-2d8d46d" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="Xamarin.Forms" version="3.1.0.697729" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/Tests/Droid/Contoso.Forms.Test.Droid.csproj
+++ b/Tests/Droid/Contoso.Forms.Test.Droid.csproj
@@ -52,24 +52,6 @@
     <Reference Include="Xamarin.Android.Arch.Core.Common">
       <HintPath>..\..\packages\Xamarin.Android.Arch.Core.Common.1.0.0\lib\MonoAndroid80\Xamarin.Android.Arch.Core.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AppCenter.Android.Bindings">
-      <HintPath>..\..\packages\Microsoft.AppCenter.1.6.1-r0008-b295835\lib\MonoAndroid403\Microsoft.AppCenter.Android.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter">
-      <HintPath>..\..\packages\Microsoft.AppCenter.1.6.1-r0008-b295835\lib\MonoAndroid403\Microsoft.AppCenter.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Analytics.Android.Bindings">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.6.1-r0008-b295835\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.Android.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Analytics">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.6.1-r0008-b295835\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Crashes.Android.Bindings">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.6.1-r0008-b295835\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.Android.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Crashes">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.6.1-r0008-b295835\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Android.Support.Annotations">
       <HintPath>..\..\packages\Xamarin.Android.Support.Annotations.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Annotations.dll</HintPath>
     </Reference>
@@ -138,6 +120,24 @@
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
       <HintPath>..\..\packages\Xamarin.Forms.3.1.0.697729\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Android.Bindings">
+      <HintPath>..\..\packages\Microsoft.AppCenter.1.10.1-r0002-2d8d46d\lib\MonoAndroid403\Microsoft.AppCenter.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter">
+      <HintPath>..\..\packages\Microsoft.AppCenter.1.10.1-r0002-2d8d46d\lib\MonoAndroid403\Microsoft.AppCenter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics.Android.Bindings">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.10.1-r0002-2d8d46d\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.10.1-r0002-2d8d46d\lib\MonoAndroid403\Microsoft.AppCenter.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Crashes.Android.Bindings">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.10.1-r0002-2d8d46d\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.Android.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Crashes">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.10.1-r0002-2d8d46d\lib\MonoAndroid403\Microsoft.AppCenter.Crashes.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Droid/MainActivity.cs
+++ b/Tests/Droid/MainActivity.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Android.App;
+﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using Com.Microsoft.Appcenter.Analytics;
@@ -54,14 +53,6 @@ namespace Contoso.Forms.Test.Droid
             if (eventlog != null)
             {
                 data.Name = eventlog.Name;
-                data.Properties = new Dictionary<string, string>();
-                if (eventlog.Properties != null)
-                {
-                    foreach (string key in eventlog.Properties.Keys)
-                    {
-                        data.Properties.Add(key, eventlog.Properties[key]);
-                    }
-                }
             }
             return data;
         }

--- a/Tests/Droid/packages.config
+++ b/Tests/Droid/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AppCenter" version="1.6.1-r0008-b295835" targetFramework="monoandroid81" />
-  <package id="Microsoft.AppCenter.Analytics" version="1.6.1-r0008-b295835" targetFramework="monoandroid81" />
-  <package id="Microsoft.AppCenter.Crashes" version="1.6.1-r0008-b295835" targetFramework="monoandroid81" />
+  <package id="Microsoft.AppCenter" version="1.10.1-r0002-2d8d46d" targetFramework="monoandroid81" />
+  <package id="Microsoft.AppCenter.Analytics" version="1.10.1-r0002-2d8d46d" targetFramework="monoandroid81" />
+  <package id="Microsoft.AppCenter.Crashes" version="1.10.1-r0002-2d8d46d" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Arch.Core.Common" version="1.0.0" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.0.3" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.0.3" targetFramework="monoandroid81" />

--- a/Tests/UITests/AnalyticsResultsHelper.cs
+++ b/Tests/UITests/AnalyticsResultsHelper.cs
@@ -35,11 +35,6 @@ namespace Contoso.Forms.Test.UITests
             }
         }
 
-        public static bool VerifyNumProperties(int count)
-        {
-            return WaitForLabelToSay(TestStrings.EventPropertiesLabel, count.ToString());
-        }
-
         public static bool VerifyEventName()
         {
             return WaitForLabelToSay(TestStrings.EventNameLabel, "UITest Event");

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -184,7 +184,6 @@ namespace Contoso.Forms.Test.UITests
             AnalyticsResultsHelper.app = app;
             Assert.IsTrue(AnalyticsResultsHelper.SendingEventWasCalled);
             Assert.IsTrue(AnalyticsResultsHelper.VerifyEventName());
-            Assert.IsTrue(AnalyticsResultsHelper.VerifyNumProperties(numProperties));
 
             /* The SDK already has retry logic. So, give it a second try. */
             Assert.IsTrue(AnalyticsResultsHelper.SentEventWasCalled || AnalyticsResultsHelper.SentEventWasCalled);
@@ -208,7 +207,6 @@ namespace Contoso.Forms.Test.UITests
             AnalyticsResultsHelper.app = app;
             Assert.IsTrue(AnalyticsResultsHelper.SendingEventWasCalled);
             Assert.IsTrue(AnalyticsResultsHelper.VerifyEventName());
-            Assert.IsTrue(AnalyticsResultsHelper.VerifyNumProperties(numProperties));
             Assert.IsTrue(AnalyticsResultsHelper.SentEventWasCalled);
             Assert.IsFalse(AnalyticsResultsHelper.FailedToSendEventWasCalled);
         }
@@ -236,7 +234,6 @@ namespace Contoso.Forms.Test.UITests
             AnalyticsResultsHelper.app = app;
             Assert.IsFalse(AnalyticsResultsHelper.SendingEventWasCalled);
             Assert.IsFalse(AnalyticsResultsHelper.VerifyEventName());
-            Assert.IsFalse(AnalyticsResultsHelper.VerifyNumProperties(numProperties));
             Assert.IsFalse(AnalyticsResultsHelper.SentEventWasCalled);
             Assert.IsFalse(AnalyticsResultsHelper.FailedToSendEventWasCalled);
         }

--- a/Tests/UITests/Tests.cs
+++ b/Tests/UITests/Tests.cs
@@ -178,7 +178,6 @@ namespace Contoso.Forms.Test.UITests
             int numProperties = 5;
             SendEvent(numProperties);
             app.Tap(TestStrings.GoToAnalyticsResultsPageButton);
-            app.WaitForElement(TestStrings.EventPropertiesLabel);
 
             /* Verify that the event was sent properly */
             AnalyticsResultsHelper.app = app;
@@ -201,7 +200,6 @@ namespace Contoso.Forms.Test.UITests
             int numProperties = 0;
             SendEvent(numProperties);
             app.Tap(TestStrings.GoToAnalyticsResultsPageButton);
-            app.WaitForElement(TestStrings.EventPropertiesLabel);
 
             /* Verify that the event was sent properly */
             AnalyticsResultsHelper.app = app;
@@ -228,7 +226,6 @@ namespace Contoso.Forms.Test.UITests
             int numProperties = 1;
             SendEvent(numProperties);
             app.Tap(TestStrings.GoToAnalyticsResultsPageButton);
-            app.WaitForElement(TestStrings.EventPropertiesLabel);
 
             /* Verify that the event was not sent */
             AnalyticsResultsHelper.app = app;

--- a/Tests/iOS/AppDelegate.cs
+++ b/Tests/iOS/AppDelegate.cs
@@ -1,8 +1,7 @@
 ﻿using Foundation;
-using UIKit;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics.iOS.Bindings;
-using System.Collections.Generic;
+using UIKit;
 
 namespace Contoso.Forms.Test.iOS
 {
@@ -43,23 +42,12 @@ namespace Contoso.Forms.Test.iOS
             EventSharer.InvokeFailedToSendEvent(LogToEventData(eventLog));
         }
 
-        private EventData LogToEventData(MSEventLog eventLog)
+        EventData LogToEventData(MSEventLog eventLog)
         {
-            var data = new EventData();
-
-            data.Name = eventLog.Name;
-            data.Properties = new Dictionary<string, string>();
-
-            if (eventLog.Properties != null)
+            var data = new EventData
             {
-                foreach (NSString nsstringKey in eventLog.Properties.Keys)
-                {
-                    string strVal = eventLog.Properties.ValueForKey(nsstringKey).ToString();
-                    string strKey = nsstringKey.ToString();
-
-                    data.Properties.Add(strKey, strVal);
-                }
-            }
+                Name = eventLog.Name
+            };
             return data;
         }
     }

--- a/Tests/iOS/Contoso.Forms.Test.iOS.csproj
+++ b/Tests/iOS/Contoso.Forms.Test.iOS.csproj
@@ -90,24 +90,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Microsoft.AppCenter">
-      <HintPath>..\..\packages\Microsoft.AppCenter.1.6.1-r0008-b295835\lib\Xamarin.iOS10\Microsoft.AppCenter.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.iOS.Bindings">
-      <HintPath>..\..\packages\Microsoft.AppCenter.1.6.1-r0008-b295835\lib\Xamarin.iOS10\Microsoft.AppCenter.iOS.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Analytics">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.6.1-r0008-b295835\lib\Xamarin.iOS10\Microsoft.AppCenter.Analytics.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Analytics.iOS.Bindings">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.6.1-r0008-b295835\lib\Xamarin.iOS10\Microsoft.AppCenter.Analytics.iOS.Bindings.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Crashes">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.6.1-r0008-b295835\lib\Xamarin.iOS10\Microsoft.AppCenter.Crashes.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AppCenter.Crashes.iOS.Bindings">
-      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.6.1-r0008-b295835\lib\Xamarin.iOS10\Microsoft.AppCenter.Crashes.iOS.Bindings.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Forms.Core">
       <HintPath>..\..\packages\Xamarin.Forms.3.1.0.697729\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
@@ -122,6 +104,24 @@
     </Reference>
     <Reference Include="Calabash">
       <HintPath>..\..\packages\Xamarin.TestCloud.Agent.0.21.6\lib\Xamarin.iOS\Calabash.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter">
+      <HintPath>..\..\packages\Microsoft.AppCenter.1.10.1-r0002-2d8d46d\lib\Xamarin.iOS10\Microsoft.AppCenter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.iOS.Bindings">
+      <HintPath>..\..\packages\Microsoft.AppCenter.1.10.1-r0002-2d8d46d\lib\Xamarin.iOS10\Microsoft.AppCenter.iOS.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Crashes">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.10.1-r0002-2d8d46d\lib\Xamarin.iOS10\Microsoft.AppCenter.Crashes.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Crashes.iOS.Bindings">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Crashes.1.10.1-r0002-2d8d46d\lib\Xamarin.iOS10\Microsoft.AppCenter.Crashes.iOS.Bindings.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.10.1-r0002-2d8d46d\lib\Xamarin.iOS10\Microsoft.AppCenter.Analytics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AppCenter.Analytics.iOS.Bindings">
+      <HintPath>..\..\packages\Microsoft.AppCenter.Analytics.1.10.1-r0002-2d8d46d\lib\Xamarin.iOS10\Microsoft.AppCenter.Analytics.iOS.Bindings.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/iOS/packages.config
+++ b/Tests/iOS/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AppCenter" version="1.6.1-r0008-b295835" targetFramework="xamarinios10" />
-  <package id="Microsoft.AppCenter.Analytics" version="1.6.1-r0008-b295835" targetFramework="xamarinios10" />
-  <package id="Microsoft.AppCenter.Crashes" version="1.6.1-r0008-b295835" targetFramework="xamarinios10" />
+  <package id="Microsoft.AppCenter" version="1.10.1-r0002-2d8d46d" targetFramework="xamarinios10" />
+  <package id="Microsoft.AppCenter.Analytics" version="1.10.1-r0002-2d8d46d" targetFramework="xamarinios10" />
+  <package id="Microsoft.AppCenter.Crashes" version="1.10.1-r0002-2d8d46d" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="3.1.0.697729" targetFramework="xamarinios10" />
   <package id="Xamarin.TestCloud.Agent" version="0.21.6" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
It becomes more complex to check property count now that schema changed.
On iOS it would require new bindings and it's not worth testing just a count.
The change was tested on 1 device config on App Center test cloud.