### PR TITLE
SDK now depends on Microsoft.NETCore.UniversalWindowsPlatform 5.2.6

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Contoso.Forms.Demo.UWP.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Contoso.Forms.Demo.UWP.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -136,7 +136,7 @@
     <PackageReference Include="Microsoft.AppCenter.Distribute" Version="1.11.0" />
     <PackageReference Include="Microsoft.AppCenter.Push" Version="1.11.0" />
     <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/project.json
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6",
     "Xamarin.Forms": "2.5.1.527436"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.14393": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/Apps/Contoso.UWP.Demo/Contoso.UWP.Demo.csproj
+++ b/Apps/Contoso.UWP.Demo/Contoso.UWP.Demo.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -131,7 +131,7 @@
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="1.11.0" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="1.11.0" />
     <PackageReference Include="Microsoft.AppCenter.Push" Version="1.11.0" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="5.2.6" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Apps/Contoso.UWP.Puppet/project.json
+++ b/Apps/Contoso.UWP.Puppet/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6",
     "Newtonsoft.Json": "10.0.2"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### UWP
 
 * **[Fix]** Downgrade the platforms verification error to a warning.
-* **[Fix]** Update vulnerable `Microsoft.NETCore.UniversalWindowsPlatform` dependency.
+* **[Fix]** Update vulnerable `Microsoft.NETCore.UniversalWindowsPlatform` dependency from version `5.2.2` to `5.2.6`.
 
 ___
 

--- a/SDK/AppCenter/Microsoft.AppCenter.UWP/project.json
+++ b/SDK/AppCenter/Microsoft.AppCenter.UWP/project.json
@@ -1,11 +1,11 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6",
     "Newtonsoft.Json": "6.0.1",
     "sqlite-net-pcl": "1.3.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.UWP/project.json
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.UWP/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/project.json
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.UWP/project.json
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.UWP/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6",
     "Newtonsoft.Json": "6.0.1"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/SDK/AppCenterRum/Microsoft.AppCenter.Rum.UWP/project.json
+++ b/SDK/AppCenterRum/Microsoft.AppCenter.Rum.UWP/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6",
     "Newtonsoft.Json": "6.0.1"
   },
   "frameworks": {

--- a/Tests/Microsoft.AppCenter.Test.UWP/project.json
+++ b/Tests/Microsoft.AppCenter.Test.UWP/project.json
@@ -1,12 +1,12 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.4",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.6",
     "Moq": "4.7.12",
     "MSTest.TestAdapter": "1.1.18",
     "MSTest.TestFramework": "1.1.18"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10240": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/nuget/AppCenter.nuspec
+++ b/nuget/AppCenter.nuspec
@@ -16,7 +16,7 @@
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group targetFramework="uap10.0">
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="5.2.4"/>
+        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="5.2.6"/>
         <dependency id="Newtonsoft.Json" version="6.0.1"/>
         <dependency id="sqlite-net-pcl" version="1.3.1"/>
       </group>

--- a/nuget/WindowsAppCenter.nuspec
+++ b/nuget/WindowsAppCenter.nuspec
@@ -16,7 +16,7 @@
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group targetFramework="uap10.0">
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="5.2.4"/>
+        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="5.2.6"/>
         <dependency id="Newtonsoft.Json" version="6.0.1"/>
         <dependency id="sqlite-net-pcl" version="1.3.1"/>
       </group>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

5.2.4 was also vulnerable.
