### PR TITLE
Don't start session from logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### UWP
 
-* **[Fix]** Extend the current session instead of starting a new session when sending events from the background. Sessions are also no longer started in background by sending an event or a log from another service such as push, as a consequence the push registration information will be missing from crash events information.
+* **[Fix]** Extend the current session instead of starting a new session when sending events from the background.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### UWP
 
-* **[Fix]** Don't start a new session from logs in the background.
+* **[Fix]** Extend the current session instead of starting a new session when sending events from the background. Sessions are also no longer started in background by sending an event or a log from another service such as push, as a consequence the push registration information will be missing from crash events information.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # App Center SDK for .NET Change Log
 
-## Version 1.12.0 
+## Version 1.12.1 (Under active development)
+
+### AppCenterAnalytics
+
+#### UWP
+
+* **[Fix]** Don't start a new session from logs in the background.
+
+___
+
+## Version 1.12.0
 
 ### AppCenter
 
@@ -35,6 +45,7 @@
 #### Android
 
 * **[Fix]** Fix `PushNotificationReceived` event for pushes received in foreground after re-enabling the push service.
+
 ___
 
 ## Version 1.11.0

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -92,7 +92,6 @@ namespace Microsoft.AppCenter.Analytics.Channel
                 {
                     return;
                 }
-                SendStartSessionIfNeeded();
                 e.Log.Sid = Sid;
                 _lastQueuedLogTime = TimeHelper.CurrentTimeInMilliseconds();
             }
@@ -123,21 +122,15 @@ namespace Microsoft.AppCenter.Analytics.Channel
         // Internal and static so that it can be tested more easily
         internal static bool HasSessionTimedOut(long now, long lastQueuedLogTime, long lastResumedTime, long lastPausedTime)
         {
-            var noLogSentForLong = lastQueuedLogTime == 0 || now - lastQueuedLogTime >= SessionTimeout;
             if (lastPausedTime == 0)
             {
-                return lastResumedTime == 0 && noLogSentForLong;
+                return false;
             }
-            if (lastResumedTime == 0)
-            {
-                return noLogSentForLong;
-            }
-            var isBackgroundForLong = lastPausedTime >= lastResumedTime && now - lastPausedTime >= SessionTimeout;
+            var noLogSentForLong = lastQueuedLogTime == 0 || now - lastQueuedLogTime >= SessionTimeout;
             var wasBackgroundForLong = lastResumedTime - Math.Max(lastPausedTime, lastQueuedLogTime) >= SessionTimeout;
             AppCenterLog.Debug(Analytics.Instance.LogTag, $"noLogSentForLong={noLogSentForLong} " +
-                                                    $"isBackgroundForLong={isBackgroundForLong} " +
                                                     $"wasBackgroundForLong={wasBackgroundForLong}");
-            return noLogSentForLong && (isBackgroundForLong || wasBackgroundForLong);
+            return noLogSentForLong && wasBackgroundForLong;
         }
 
         internal static bool SetExistingSessionId(Log log, IDictionary<long, Guid> sessions)

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Channel/SessionTracker.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Channel/SessionTracker.cs
@@ -35,7 +35,8 @@ namespace Microsoft.AppCenter.Analytics.Channel
         // Since we don't have session history anymore, when disabling /enabling analytics a new instance is created.
         // But the correlation identifier in AppCenter is static and thus updating session will fail test and set if we don't know previous value.
         // The field is thus static to remember previous sessions across instances... Internal because read and reset in tests.
-        internal static Guid Sid;
+        internal static Guid LastSid;
+        private Guid? _sid;
         private long _lastQueuedLogTime;
         private long _lastResumedTime;
         private long _lastPausedTime;
@@ -92,7 +93,7 @@ namespace Microsoft.AppCenter.Analytics.Channel
                 {
                     return;
                 }
-                e.Log.Sid = Sid;
+                e.Log.Sid = _sid;
                 _lastQueuedLogTime = TimeHelper.CurrentTimeInMilliseconds();
             }
         }
@@ -100,17 +101,18 @@ namespace Microsoft.AppCenter.Analytics.Channel
         private void SendStartSessionIfNeeded()
         {
             var now = TimeHelper.CurrentTimeInMilliseconds();
-            if (_lastQueuedLogTime > 0 && !HasSessionTimedOut(now))
+            if (_sid != null && !HasSessionTimedOut(now))
             {
                 return;
             }
-            var previousSid = Sid;
-            Sid = Guid.NewGuid();
+            var sid = Guid.NewGuid();
 #pragma warning disable CS0612 // Type or member is obsolete
-            AppCenter.TestAndSetCorrelationId(previousSid, ref Sid);
+            AppCenter.TestAndSetCorrelationId(LastSid, ref sid);
 #pragma warning restore CS0612 // Type or member is obsolete
+            LastSid = sid;
+            _sid = sid;
             _lastQueuedLogTime = TimeHelper.CurrentTimeInMilliseconds();
-            var startSessionLog = new StartSessionLog { Sid = Sid };
+            var startSessionLog = new StartSessionLog { Sid = sid };
             _channel.EnqueueAsync(startSessionLog);
         }
 

--- a/Tests/Microsoft.AppCenter.Analytics.Test.Windows/SessionTrackerTest.cs
+++ b/Tests/Microsoft.AppCenter.Analytics.Test.Windows/SessionTrackerTest.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AppCenter.Analytics.Test.Windows
         }
 
         /// <summary>
-        ///     Verify that an enqueuing log is adjusted and a session is started when a log is enqueued
+        ///     Verify that an enqueuing log is adjusted and a session is not started when a log is enqueued
         /// </summary>
         [TestMethod]
         public void HandleEnqueuingLogOutsideSession()
@@ -127,7 +127,7 @@ namespace Microsoft.AppCenter.Analytics.Test.Windows
             var eventArgs = new EnqueuingLogEventArgs(eventLog);
             _mockChannelGroup.Raise(group => group.EnqueuingLog += null, null, eventArgs);
 
-            _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<StartSessionLog>()), Times.Once());
+            _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<StartSessionLog>()), Times.Never());
             Assert.IsNotNull(eventLog.Sid);
         }
 
@@ -194,20 +194,6 @@ namespace Microsoft.AppCenter.Analytics.Test.Windows
 
             Assert.IsFalse(success);
             Assert.IsFalse(log.Sid.HasValue);
-        }
-
-        /// <summary>
-        ///     Verify session timeout is true if log was never sent and only pause has occurred
-        /// </summary>
-        [TestMethod]
-        public void HasSessionTimedOutPausedNeverResumed()
-        {
-            const long now = 10;
-            const long lastQueuedLogTime = 0;
-            const long lastResumedTime = 0;
-            const long lastPausedTime = 5;
-
-            Assert.IsTrue(SessionTracker.HasSessionTimedOut(now, lastQueuedLogTime, lastResumedTime, lastPausedTime));
         }
 
         /// <summary>


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

1. Schedule track event every 30s
2. Minimize the app into the background
3. Observe that every event creates a new session

Expected behavior:
Like iOS, sending a log just extends current session lifetime but must not trigger a new session.