### PR TITLE
Fix bug where Xamarin.iOS would crash when the userId was set to null

### DIFF
--- a/Apps/Contoso.Android.Puppet/ModulePages/AppCenterFragment.cs
+++ b/Apps/Contoso.Android.Puppet/ModulePages/AppCenterFragment.cs
@@ -116,7 +116,8 @@ namespace Contoso.Android.Puppet
         {
             if (e.Event.Action == KeyEventActions.Down && e.KeyCode == Keycode.Enter)
             {
-                AppCenter.SetUserId(UserIdText.Text);
+                var text = string.IsNullOrEmpty(UserIdText.Text) ? null : UserIdText.Text;
+                AppCenter.SetUserId(text);
             }
         }
 

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -30,7 +30,8 @@ namespace Contoso.Forms.Demo
         void UserIdCompleted(object sender, EventArgs e)
         {
             //TODO: Enable this once NuGet package is updated as part of release process.
-            //AppCenter.SetUserId(UserIdEntryCell.Text);
+            //var text = string.IsNullOrEmpty(UserIdEntryCell.Text) ? null : UserIdEntryCell.Text;
+            //AppCenter.SetUserId(text);
         }
     }
 }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -89,7 +89,8 @@ namespace Contoso.Forms.Puppet
 
         void UserIdCompleted(object sender, EventArgs e)
         {
-            AppCenter.SetUserId(UserIdEntryCell.Text);
+            var text = string.IsNullOrEmpty(UserIdEntryCell.Text) ? null : UserIdEntryCell.Text;
+            AppCenter.SetUserId(text);
         }
     }
 }

--- a/Apps/Contoso.iOS.Puppet/ModulePages/AppCenterController.cs
+++ b/Apps/Contoso.iOS.Puppet/ModulePages/AppCenterController.cs
@@ -38,7 +38,8 @@ namespace Contoso.iOS.Puppet
 
         partial void UpdateUserId(UITextField sender)
         {
-            AppCenter.SetUserId(sender.Text);
+            var text = string.IsNullOrEmpty(sender.Text) ? null : sender.Text;
+            AppCenter.SetUserId(text);
         }
 
         public override void PrepareForSegue(UIStoryboardSegue segue, NSObject sender)

--- a/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/ApiDefinition.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AppCenter.iOS.Bindings
         // + (void)setUserId:(NSString *)userId;
         [Static]
         [Export("setUserId:")]
-        void SetUserId(string userId);
+        void SetUserId([NullAllowed] string userId);
 
         // +(void)setLogHandler:(MSLogHandler)logHandler;
         [Static]


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix an issue where Xamarin.iOS would throw if `AppCenter.SetUserId` was set with a `null` value. Update the test Apps to check for this scenario as well.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
