### PR TITLE
Add SetCountryCode example to Puppet

### DIFF
--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Push;
@@ -57,7 +58,7 @@ namespace Contoso.Forms.Puppet.UWP
                     {
                         MapService.ServiceToken = Constants.BingMapsToken;
                     }
-                    catch (Exception e)
+                    catch (SEHException tokenException)
                     {
                         AppCenterLog.Info(LogTag, "Please provide a valid Bing Maps token/ For more info see: https://docs.microsoft.com/en-us/windows/uwp/maps-and-location/authentication-key");
                     }
@@ -72,10 +73,10 @@ namespace Contoso.Forms.Puppet.UWP
                         break;
                     }
                     countryCode = new GeographicRegion(country).CodeTwoLetter;
-                        break;
-                    case GeolocationAccessStatus.Denied:
-                    case GeolocationAccessStatus.Unspecified:
-                        break;
+                    break;
+                case GeolocationAccessStatus.Denied:
+                case GeolocationAccessStatus.Unspecified:
+                    break;
             }
             AppCenter.SetCountryCode(countryCode);
         }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -29,7 +29,9 @@ namespace Contoso.Forms.Puppet.UWP
         public App()
         {
             // Set the country before initialization occurs so App Center can send the field to the backend.
-            SetCountryCode().Wait();
+            // We do not use await here because we don't need to wait for this task to complete,
+            // and await would block the UI in App constructor.
+            _ = SetCountryCode();
             EventFilterHolder.Implementation = new EventFilterWrapper();
             InitializeComponent();
             Suspending += OnSuspending;

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Push;
 using Windows.ApplicationModel;
@@ -33,7 +34,7 @@ namespace Contoso.Forms.Puppet.UWP
             Suspending += OnSuspending;
         }
 
-        async public static void SetCountryCode()
+        public static async Task SetCountryCode()
         {
             // The following country code is used only as a fallback for the main implementation.
             // This fallback country code does not reflect the physical device location, but rather the

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -47,8 +47,10 @@ namespace Contoso.Forms.Puppet.UWP
             switch (accessStatus)
             {
                 case GeolocationAccessStatus.Allowed:
-                    var geoLocator = new Geolocator();
-                    geoLocator.DesiredAccuracyInMeters = 100;
+                    var geoLocator = new Geolocator
+                    {
+                        DesiredAccuracyInMeters = 100
+                    };
                     var position = await geoLocator.GetGeopositionAsync();
                     var myLocation = new BasicGeoposition
                     {

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -25,14 +25,14 @@ namespace Contoso.Forms.Puppet.UWP
         /// </summary>
         public App()
         {
-            EventFilterHolder.Implementation = new EventFilterWrapper();
-            InitializeComponent();
-            Suspending += OnSuspending;
             // Set the country before initialization occurs so App Center can send the field to the backend
             // Note that the country code provided does not reflect the physical device location, but rather the
             // country that corresponds to the culture it uses. You may wish to retrieve the country code using
             // a different means, such as device location.
             SetCountryCode();
+            EventFilterHolder.Implementation = new EventFilterWrapper();
+            InitializeComponent();
+            Suspending += OnSuspending;
         }
 
         async public static void SetCountryCode()

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -75,10 +75,6 @@ namespace Contoso.Forms.Puppet.UWP
                     // The returned country code is in 3-letter format (ISO 3166-1 alpha-3).
                     // Below we convert it to ISO 3166-1 alpha-2 (two letter).
                     var country = result.Locations[0].Address.CountryCode;
-                    if (country == null)
-                    {
-                        break;
-                    }
                     countryCode = new GeographicRegion(country).CodeTwoLetter;
                     break;
                 case GeolocationAccessStatus.Denied:

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -60,13 +60,16 @@ namespace Contoso.Forms.Puppet.UWP
                     }
                     catch (SEHException tokenException)
                     {
-                        AppCenterLog.Info(LogTag, "Please provide a valid Bing Maps token/ For more info see: https://docs.microsoft.com/en-us/windows/uwp/maps-and-location/authentication-key");
+                        AppCenterLog.Info(LogTag, "Please provide a valid Bing Maps token. For more info see: https://docs.microsoft.com/en-us/windows/uwp/maps-and-location/authentication-key");
                     }
                     var result = await MapLocationFinder.FindLocationsAtAsync(pointToReverseGeocode);
                     if (result.Status != MapLocationFinderStatus.Success || result.Locations == null || result.Locations.Count == 0)
                     {
                         break;
                     }
+
+                    // The returned country code is in 3-letter format (ISO 3166-1 alpha-3).
+                    // Below we convert it to ISO 3166-1 alpha-2 (two letter).
                     string country = result.Locations[0].Address.CountryCode;
                     if (country == null)
                     {

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -26,10 +26,7 @@ namespace Contoso.Forms.Puppet.UWP
         /// </summary>
         public App()
         {
-            // Set the country before initialization occurs so App Center can send the field to the backend
-            // Note that the country code provided does not reflect the physical device location, but rather the
-            // country that corresponds to the culture it uses. You may wish to retrieve the country code using
-            // a different means, such as device location.
+            // Set the country before initialization occurs so App Center can send the field to the backend.
             SetCountryCode();
             EventFilterHolder.Implementation = new EventFilterWrapper();
             InitializeComponent();
@@ -38,6 +35,9 @@ namespace Contoso.Forms.Puppet.UWP
 
         async public static void SetCountryCode()
         {
+            // The following country code is used only as a fallback for the main implementation.
+            // This fallback country code does not reflect the physical device location, but rather the
+            // country that corresponds to the culture it uses. 
             var fallbackGeographicRegion = new GeographicRegion();
             var fallbackCountryCode = fallbackGeographicRegion.CodeTwoLetter;
             var accessStatus = await Geolocator.RequestAccessAsync();

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -37,9 +37,8 @@ namespace Contoso.Forms.Puppet.UWP
         {
             // The following country code is used only as a fallback for the main implementation.
             // This fallback country code does not reflect the physical device location, but rather the
-            // country that corresponds to the culture it uses. 
-            var fallbackGeographicRegion = new GeographicRegion();
-            var fallbackCountryCode = fallbackGeographicRegion.CodeTwoLetter;
+            // country that corresponds to the culture it uses.
+            var countryCode = new GeographicRegion().CodeTwoLetter;
             var accessStatus = await Geolocator.RequestAccessAsync();
             switch (accessStatus)
             {
@@ -64,24 +63,20 @@ namespace Contoso.Forms.Puppet.UWP
                     var result = await MapLocationFinder.FindLocationsAtAsync(pointToReverseGeocode);
                     if (result.Status != MapLocationFinderStatus.Success || result.Locations == null || result.Locations.Count == 0)
                     {
-                        AppCenter.SetCountryCode(fallbackCountryCode);
                         break;
                     }
                     string country = result.Locations[0].Address.CountryCode;
                     if (country == null)
                     {
-                        AppCenter.SetCountryCode(fallbackCountryCode);
                         break;
                     }
-                    var geographicRegion = new GeographicRegion(country);
-                    var countryCode = geographicRegion.CodeTwoLetter;
-                    AppCenter.SetCountryCode(countryCode);
+                    countryCode = new GeographicRegion(country).CodeTwoLetter;
                         break;
                     case GeolocationAccessStatus.Denied:
                     case GeolocationAccessStatus.Unspecified:
-                        AppCenter.SetCountryCode(fallbackCountryCode);
                         break;
-               }
+            }
+            AppCenter.SetCountryCode(countryCode);
         }
 
         /// <summary>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -19,6 +19,7 @@ namespace Contoso.Forms.Puppet.UWP
     sealed partial class App : Application
     {
         public const string LogTag = "AppCenterXamarinPuppet";
+
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -26,20 +26,20 @@ namespace Contoso.Forms.Puppet.UWP
         /// </summary>
         public App()
         {
-            // Set the country before initialization occurs so App Center can send the field to the backend.
-            SetCountryCode();
+            // First we synchronously set a fallback country code before initialization occurs.
+            // This fallback country code does not reflect the physical device location, but rather the
+            // country that corresponds to the culture it uses. 
+            AppCenter.SetCountryCode(new GeographicRegion().CodeTwoLetter);
+
+            // Then asynchronously set the country code using location service, which is a more proper way to retrieve it.
+            SetCountryCodeAsync();
             EventFilterHolder.Implementation = new EventFilterWrapper();
             InitializeComponent();
             Suspending += OnSuspending;
         }
 
-        async public static void SetCountryCode()
+        async public static void SetCountryCodeAsync()
         {
-            // The following country code is used only as a fallback for the main implementation.
-            // This fallback country code does not reflect the physical device location, but rather the
-            // country that corresponds to the culture it uses. 
-            var fallbackGeographicRegion = new GeographicRegion();
-            var fallbackCountryCode = fallbackGeographicRegion.CodeTwoLetter;
             var accessStatus = await Geolocator.RequestAccessAsync();
             switch (accessStatus)
             {
@@ -64,22 +64,17 @@ namespace Contoso.Forms.Puppet.UWP
                     var result = await MapLocationFinder.FindLocationsAtAsync(pointToReverseGeocode);
                     if (result.Status != MapLocationFinderStatus.Success || result.Locations == null || result.Locations.Count == 0)
                     {
-                        AppCenter.SetCountryCode(fallbackCountryCode);
                         break;
                     }
                     string country = result.Locations[0].Address.CountryCode;
                     if (country == null)
                     {
-                        AppCenter.SetCountryCode(fallbackCountryCode);
                         break;
                     }
-                    var geographicRegion = new GeographicRegion(country);
-                    var countryCode = geographicRegion.CodeTwoLetter;
-                    AppCenter.SetCountryCode(countryCode);
+                    AppCenter.SetCountryCode(new GeographicRegion(country).CodeTwoLetter);
                         break;
                     case GeolocationAccessStatus.Denied:
                     case GeolocationAccessStatus.Unspecified:
-                        AppCenter.SetCountryCode(fallbackCountryCode);
                         break;
                }
         }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/App.xaml.cs
@@ -4,13 +4,12 @@ using Microsoft.AppCenter;
 using Microsoft.AppCenter.Push;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.Devices.Geolocation;
+using Windows.Globalization;
+using Windows.Services.Maps;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using Windows.Devices.Geolocation;
-using Windows.Services.Maps;
-using Windows.Globalization;
-using System.Globalization;
 
 namespace Contoso.Forms.Puppet.UWP
 {

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Package.appxmanifest
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Package.appxmanifest
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
   <Identity Name="10805zumoTestUser.AppCenter-Contoso.Forms.Puppet.U" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="1.13.1.0" />
   <mp:PhoneIdentity PhoneProductId="55497ed8-b2ac-4485-ba79-e2b65bb720ed" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
@@ -25,5 +25,6 @@
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
+    <DeviceCapability Name="location" />
   </Capabilities>
 </Package>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Constants.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Constants.cs
@@ -8,5 +8,6 @@
         public const string Info = "Info";
         public const string Warning = "Warning";
         public const string Error = "Error";
+        public const string BingMapsToken = "paste-token-here";
     }
 }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Constants.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Constants.cs
@@ -8,6 +8,6 @@
         public const string Info = "Info";
         public const string Warning = "Warning";
         public const string Error = "Error";
-        public const string BingMapsToken = "paste-token-here";
+        public const string BingMapsAuthKey = "paste-key-here";
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests if this modifies the UWP implementation?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add example of `AppCenter.SetCountryCode` usage to Puppet.

## Related PRs or issues
**Relevant docs PR:** https://github.com/MicrosoftDocs/appcenter-docs-pr/pull/1083
Request: #362 
Old implementation: #577 
Old PR in AppCenter docs: https://github.com/MicrosoftDocs/appcenter-docs/pull/421
Issue in AppCenter docs: https://github.com/MicrosoftDocs/appcenter-docs/issues/54

## Misc
**Note:** in order for this example to work properly, we will need to obtain [Bing Maps Token](https://docs.microsoft.com/en-us/windows/uwp/maps-and-location/authentication-key#get-a-key) and paste it in `Constants`.
