### PR TITLE
Fix a crash on iOS when null reference exceptions are triggered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # App Center SDK for .NET Change Log
 
+## Version 1.13.1 (Not yet released)
+
+### AppCenterCrashes
+
+#### iOS
+
+* **[Fix]** Fix a crash on iOS when triggering null reference exception and starting Crashes in background. The conditon might still occur very rarely if trigger a null reference exception in another thread during the short time where the [SDK configures native crash reporter](https://www.mono-project.com/docs/advanced/signals/). It is thus recommended to initialize AppCenter Crashes as early as possible (which is also recommended to capture early crashes).
+
+___
+
 ## Version 1.13.0 
 
 ### AppCenter

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -78,13 +78,18 @@ namespace Microsoft.AppCenter.Crashes
         /// <summary>
         /// We keep the reference to avoid it being freed, inlining this object will cause listeners not to be called.
         /// </summary>
+        static readonly CrashesInitializationDelegate _crashesInitializationDelegate = new CrashesInitializationDelegate();
+
+        /// <summary>
+        /// We keep the reference to avoid it being freed, inlining this object will cause listeners not to be called.
+        /// </summary>
         static readonly CrashesDelegate _crashesDelegate = new CrashesDelegate();
 
         static Crashes()
         {
             /* Perform custom setup around the native SDK's for setting signal handlers */
             MSCrashes.DisableMachExceptionHandler();
-            MSWrapperCrashesHelper.SetCrashHandlerSetupDelegate(new CrashesInitializationDelegate());
+            MSWrapperCrashesHelper.SetCrashHandlerSetupDelegate(_crashesInitializationDelegate);
             AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
             MSCrashes.SetUserConfirmationHandler((reports) =>
                     {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The weak reference of the listener to configure mono signal handlers was freed before execution
if starting Crashes from a Task.

#759