### PR TITLE
Set oncolor property for switchcell when switchcell is enabled

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml
@@ -4,5 +4,6 @@
              x:Class="Contoso.Forms.Demo.App">
     <Application.Resources>
         <!-- Application resource dictionary -->
+        <Color x:Key="SwitchCellOnColor">Accent</Color>
     </Application.Resources>
 </Application>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AnalyticsContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AnalyticsContentPage.xaml
@@ -5,7 +5,7 @@
              x:Class="Contoso.Forms.Demo.AnalyticsContentPage">
     <TableView Intent="Form">
         <TableSection Title="Analytics Settings">
-            <SwitchCell Text="Analytics Enabled" On="true" x:Name="EnabledSwitchCell" OnChanged="UpdateEnabled" />
+            <SwitchCell Text="Analytics Enabled" On="true" x:Name="EnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="Accent" />
         </TableSection>
         <TableSection Title="Tracking Events">
             <EntryCell Label="Event Name" HorizontalTextAlignment="Start" x:Name="EventNameCell" />

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AnalyticsContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AnalyticsContentPage.xaml
@@ -5,7 +5,7 @@
              x:Class="Contoso.Forms.Demo.AnalyticsContentPage">
     <TableView Intent="Form">
         <TableSection Title="Analytics Settings">
-            <SwitchCell Text="Analytics Enabled" On="true" x:Name="EnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="Accent" />
+            <SwitchCell Text="Analytics Enabled" On="true" x:Name="EnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="{StaticResource SwitchCellOnColor}" />
         </TableSection>
         <TableSection Title="Tracking Events">
             <EntryCell Label="Event Name" HorizontalTextAlignment="Start" x:Name="EventNameCell" />

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
@@ -5,7 +5,7 @@
              x:Class="Contoso.Forms.Demo.AppCenterContentPage">
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
-            <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled"/>
+            <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="Accent"/>
         </TableSection>
         <TableSection Title="Logging">
             <EntryCell Label="User Id" x:Name="UserIdEntryCell" HorizontalTextAlignment="End" Completed="UserIdCompleted"/>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
@@ -5,7 +5,7 @@
              x:Class="Contoso.Forms.Demo.AppCenterContentPage">
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
-            <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="Accent"/>
+            <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="{StaticResource SwitchCellOnColor}"/>
         </TableSection>
         <TableSection Title="Logging">
             <EntryCell Label="User Id" x:Name="UserIdEntryCell" HorizontalTextAlignment="End" Completed="UserIdCompleted"/>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml
@@ -5,8 +5,8 @@
              x:Class="Contoso.Forms.Demo.CrashesContentPage">
     <TableView Intent="Form">
         <TableSection Title="Crashes Settings">
-            <SwitchCell Text="Crashes Enabled" On="true" x:Name="CrashesEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="Accent" />
-            <SwitchCell Text="Handle Exceptions" On="false" x:Name="HandleExceptionsSwitchCell" OnColor="Accent" />
+            <SwitchCell Text="Crashes Enabled" On="true" x:Name="CrashesEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="{StaticResource SwitchCellOnColor}" />
+                <SwitchCell Text="Handle Exceptions" On="false" x:Name="HandleExceptionsSwitchCell" OnColor="{StaticResource SwitchCellOnColor}" />
             <TextCell Text="Text Attachment" x:Name="TextAttachmentCell" Tapped="TextAttachment" />
             <TextCell Text="Binary Attachment" x:Name="FileAttachmentCell" Tapped="FileAttachment" />
             <ViewCell Tapped="PropertiesCellTapped">

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml
@@ -5,8 +5,8 @@
              x:Class="Contoso.Forms.Demo.CrashesContentPage">
     <TableView Intent="Form">
         <TableSection Title="Crashes Settings">
-            <SwitchCell Text="Crashes Enabled" On="true" x:Name="CrashesEnabledSwitchCell" OnChanged="UpdateEnabled" />
-            <SwitchCell Text="Handle Exceptions" On="false" x:Name="HandleExceptionsSwitchCell" />
+            <SwitchCell Text="Crashes Enabled" On="true" x:Name="CrashesEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="Accent" />
+            <SwitchCell Text="Handle Exceptions" On="false" x:Name="HandleExceptionsSwitchCell" OnColor="Accent" />
             <TextCell Text="Text Attachment" x:Name="TextAttachmentCell" Tapped="TextAttachment" />
             <TextCell Text="Binary Attachment" x:Name="FileAttachmentCell" Tapped="FileAttachment" />
             <ViewCell Tapped="PropertiesCellTapped">

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml
@@ -5,10 +5,10 @@
              x:Class="Contoso.Forms.Demo.OthersContentPage">
     <TableView Intent="Form">
         <TableSection Title="Distribute">
-            <SwitchCell Text="Distribute Enabled" On="true" x:Name="DistributeEnabledSwitchCell" OnChanged="UpdateDistributeEnabled" OnColor="Accent"/>
+            <SwitchCell Text="Distribute Enabled" On="true" x:Name="DistributeEnabledSwitchCell" OnChanged="UpdateDistributeEnabled" OnColor="{StaticResource SwitchCellOnColor}"/>
         </TableSection>
         <TableSection Title="Push">
-            <SwitchCell Text="Push Enabled" On="true" x:Name="PushEnabledSwitchCell" OnChanged="UpdatePushEnabled" OnColor="Accent"/>
+            <SwitchCell Text="Push Enabled" On="true" x:Name="PushEnabledSwitchCell" OnChanged="UpdatePushEnabled" OnColor="{StaticResource SwitchCellOnColor}"/>
         </TableSection>
     </TableView>
 </ContentPage>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml
@@ -5,10 +5,10 @@
              x:Class="Contoso.Forms.Demo.OthersContentPage">
     <TableView Intent="Form">
         <TableSection Title="Distribute">
-            <SwitchCell Text="Distribute Enabled" On="true" x:Name="DistributeEnabledSwitchCell" OnChanged="UpdateDistributeEnabled"/>
+            <SwitchCell Text="Distribute Enabled" On="true" x:Name="DistributeEnabledSwitchCell" OnChanged="UpdateDistributeEnabled" OnColor="Accent"/>
         </TableSection>
         <TableSection Title="Push">
-            <SwitchCell Text="Push Enabled" On="true" x:Name="PushEnabledSwitchCell" OnChanged="UpdatePushEnabled"/>
+            <SwitchCell Text="Push Enabled" On="true" x:Name="PushEnabledSwitchCell" OnChanged="UpdatePushEnabled" OnColor="Accent"/>
         </TableSection>
     </TableView>
 </ContentPage>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Set the oncolor property for switchcell to display it when switchcell is enabled.
Reason:
This issue is only re-pro on master branch. 
On master branch, the version of xamarin.forms is update to 3.5. And in xamarin.forms 3.5,  the default color for enabled switch cell is none, so we can't see the enabled toggle switch after enabled it. 
So we need to set the color for switch cell manually. 
(In xamarin.forms 3.4, the switch cell has the default color as windows theme color)

## Related PRs or issues

Bug: [[SDK demo App] If the App Center switch is off, enable it to on, then the switch of App Center, Analytics and Push are all out of sight on UWP demo ](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/57248)

