### PR TITLE
Fix bug 57688 : [DotNet] User Id doesn't work for SDK 1.13.2

### DIFF
--- a/Apps/Contoso.Android.Puppet/ModulePages/AppCenterFragment.cs
+++ b/Apps/Contoso.Android.Puppet/ModulePages/AppCenterFragment.cs
@@ -114,7 +114,7 @@ namespace Contoso.Android.Puppet
 
         private void UserIdTextKeyPressedHandler(object sender, View.KeyEventArgs e)
         {
-            if (e.Event.Action == KeyEventActions.Down && e.KeyCode == Keycode.Enter)
+            if ((e.Event.Action == KeyEventActions.Down && e.KeyCode == Keycode.Enter) || (e.Event.Action == KeyEventActions.Up))
             {
                 var text = string.IsNullOrEmpty(UserIdText.Text) ? null : UserIdText.Text;
                 AppCenter.SetUserId(text);

--- a/Apps/Contoso.Android.Puppet/ModulePages/AppCenterFragment.cs
+++ b/Apps/Contoso.Android.Puppet/ModulePages/AppCenterFragment.cs
@@ -114,7 +114,7 @@ namespace Contoso.Android.Puppet
 
         private void UserIdTextKeyPressedHandler(object sender, View.KeyEventArgs e)
         {
-            if ((e.Event.Action == KeyEventActions.Down && e.KeyCode == Keycode.Enter) || (e.Event.Action == KeyEventActions.Up))
+            if (e.Event.Action == KeyEventActions.Up)
             {
                 var text = string.IsNullOrEmpty(UserIdText.Text) ? null : UserIdText.Text;
                 AppCenter.SetUserId(text);


### PR DESCRIPTION

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

We found that press enter after input any key the key action will be 'DOWN', Otherwise it will be 'UP',
So add another choice to set the user id.
![image](https://user-images.githubusercontent.com/29274908/53558194-736fba00-3b82-11e9-87e8-1b7cd4a957b3.png)

