### PR TITLE
fix No intellisense for Crash, Distribute, Push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # App Center SDK for .NET Change Log
 
+## Version Next
+
+### AppCenterCrashes
+
+* **[Fix]** Fix intellisense for APIs.
+
+### AppCenterDistribute
+
+* **[Fix]** Fix intellisense for APIs.
+
+### AppCenterPush
+
+* **[Fix]** Fix intellisense for APIs.
+
 ## Version 1.14.0
 
 ### AppCenter

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Microsoft.AppCenter.Crashes.Android.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Microsoft.AppCenter.Crashes.Android.csproj
@@ -37,6 +37,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Microsoft.AppCenter.Crashes.xml</DocumentationFile>
     <ExternalConsole>false</ExternalConsole>
   </PropertyGroup>
   <ItemGroup>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Microsoft.AppCenter.Crashes.iOS.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Microsoft.AppCenter.Crashes.iOS.csproj
@@ -24,6 +24,7 @@
     </MtouchHttpClientHandler>
     <MtouchTlsProvider>
     </MtouchTlsProvider>
+    <DocumentationFile>bin\Debug\Microsoft.AppCenter.Crashes.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -38,6 +39,7 @@
     </MtouchHttpClientHandler>
     <MtouchTlsProvider>
     </MtouchTlsProvider>
+    <DocumentationFile>bin\Release\Microsoft.AppCenter.Crashes.xml</DocumentationFile>  
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.Android/Microsoft.AppCenter.Push.Android.csproj
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.Android/Microsoft.AppCenter.Push.Android.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Microsoft.AppCenter.Push.xml</DocumentationFile>
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -31,6 +32,7 @@
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Microsoft.AppCenter.Push.xml</DocumentationFile>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.iOS/Microsoft.AppCenter.Push.iOS.csproj
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.iOS/Microsoft.AppCenter.Push.iOS.csproj
@@ -26,6 +26,7 @@
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
     <MtouchLink></MtouchLink>
     <MtouchHttpClientHandler></MtouchHttpClientHandler>
+    <DocumentationFile>bin\Debug\Microsoft.AppCenter.Push.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,6 +39,7 @@
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchHttpClientHandler></MtouchHttpClientHandler>
+    <DocumentationFile>bin\Release\Microsoft.AppCenter.Push.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/nuget/AppCenterCrashes.nuspec
+++ b/nuget/AppCenterCrashes.nuspec
@@ -23,9 +23,11 @@
 
     <!-- Portable -->
     <file src="$pcl_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/portable-net45+win8+wpa81+wp8" />
+    <file src="$pcl_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/portable-net45+win8+wpa81+wp8" />
 
     <!-- .NET Standard -->
     <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/netstandard1.0" />
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/MonoAndroid403" />
@@ -43,19 +45,23 @@
     <!-- targets files add correct references to proper platforms -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.targets" target="build/uap10.0"/>
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="ref/uap10.0" />
+    <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.xml" target="ref/uap10.0" />
 
     <!--x86 -->
     <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x86/lib/uap10.0" />
+    <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.xml" target="runtimes/win10-x86/lib/uap10.0" />
     <file src="$uwp_dir$/x86/WatsonRegistrationUtility.dll"  target="runtimes/win10-x86/native"/>
     <file src="$uwp_dir$/x86/WatsonRegistrationUtility.winmd" target="runtimes/win10-x86/lib/uap10.0" />
 
     <!-- x64 -->
     <file src="$uwp_dir$/x64/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x64/lib/uap10.0" />
+    <file src="$uwp_dir$/x64/Microsoft.AppCenter.Crashes.xml" target="runtimes/win10-x64/lib/uap10.0" />
     <file src="$uwp_dir$/x64/WatsonRegistrationUtility.dll"  target="runtimes/win10-x64/native"/>
     <file src="$uwp_dir$/x64/WatsonRegistrationUtility.winmd" target="runtimes/win10-x64/lib/uap10.0" />
 
     <!-- ARM -->
     <file src="$uwp_dir$/ARM/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-arm/lib/uap10.0" />
+    <file src="$uwp_dir$/ARM/Microsoft.AppCenter.Crashes.xml" target="runtimes/win10-arm/lib/uap10.0" />
     <file src="$uwp_dir$/ARM/WatsonRegistrationUtility.dll"  target="runtimes/win10-arm/native"/>
     <file src="$uwp_dir$/ARM/WatsonRegistrationUtility.winmd" target="runtimes/win10-arm/lib/uap10.0" />
 

--- a/nuget/AppCenterDistribute.nuspec
+++ b/nuget/AppCenterDistribute.nuspec
@@ -23,16 +23,20 @@
 
     <!-- Portable -->
     <file src="$pcl_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/portable-net45+win8+wpa81+wp8" />
+    <file src="$pcl_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/portable-net45+win8+wpa81+wp8" />
 
     <!-- .NET Standard -->
     <file src="$netstandard_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/netstandard1.0" />
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/MonoAndroid403" />
+    <file src="$android_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/MonoAndroid403" />
     <file src="$android_dir$/Microsoft.AppCenter.Distribute.Android.Bindings.dll" target="lib/MonoAndroid403" />
 
     <!-- iOS -->
     <file src="$ios_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/Xamarin.iOS10" />
+    <file src="$ios_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Distribute.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
   </files>

--- a/nuget/AppCenterPush.nuspec
+++ b/nuget/AppCenterPush.nuspec
@@ -39,20 +39,25 @@
 
     <!-- Portable -->
     <file src="$pcl_dir$/Microsoft.AppCenter.Push.dll" target="lib/portable-net45+win8+wpa81+wp8" />
+    <file src="$pcl_dir$/Microsoft.AppCenter.Push.xml" target="lib/portable-net45+win8+wpa81+wp8" />
 
     <!-- .NET Standard -->
     <file src="$netstandard_dir$/Microsoft.AppCenter.Push.dll" target="lib/netstandard1.0" />
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Push.xml" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Push.dll" target="lib/MonoAndroid403" />
+    <file src="$android_dir$/Microsoft.AppCenter.Push.xml" target="lib/MonoAndroid403" />
     <file src="$android_dir$/Microsoft.AppCenter.Push.Android.Bindings.dll" target="lib/MonoAndroid403" />
 
     <!-- iOS -->
     <file src="$ios_dir$/Microsoft.AppCenter.Push.dll" target="lib/Xamarin.iOS10" />
+    <file src="$ios_dir$/Microsoft.AppCenter.Push.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Push.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
     <!-- UWP -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Push.dll" target="lib/uap10.0" />
+    <file src="$uwp_dir$/Microsoft.AppCenter.Push.xml" target="lib/uap10.0" />
 
   </files>
 </package>

--- a/nuget/MacAppCenterCrashes.nuspec
+++ b/nuget/MacAppCenterCrashes.nuspec
@@ -27,7 +27,6 @@
     <!-- .NET Standard -->
     <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/netstandard1.0" />
     <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/netstandard1.0" />
-    <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/MonoAndroid403" />

--- a/nuget/MacAppCenterCrashes.nuspec
+++ b/nuget/MacAppCenterCrashes.nuspec
@@ -22,16 +22,21 @@
 
     <!-- Portable -->
     <file src="$pcl_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/portable-net45+win8+wpa81+wp8" />
+    <file src="$pcl_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/portable-net45+win8+wpa81+wp8" />
 
     <!-- .NET Standard -->
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/netstandard1.0" />
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/netstandard1.0" />
     <file src="$netstandard_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/MonoAndroid403" />
+    <file src="$android_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/MonoAndroid403" />
     <file src="$android_dir$/Microsoft.AppCenter.Crashes.Android.Bindings.dll" target="lib/MonoAndroid403" />
 
     <!-- iOS -->
     <file src="$ios_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/Xamarin.iOS10" />
+    <file src="$ios_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Crashes.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
   </files>

--- a/nuget/MacAppCenterDistribute.nuspec
+++ b/nuget/MacAppCenterDistribute.nuspec
@@ -22,16 +22,20 @@
 
     <!-- Portable -->
     <file src="$pcl_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/portable-net45+win8+wpa81+wp8" />
+    <file src="$pcl_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/portable-net45+win8+wpa81+wp8" />
 
     <!-- .NET Standard -->
     <file src="$netstandard_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/netstandard1.0" />
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/MonoAndroid403" />
+    <file src="$android_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/MonoAndroid403" />
     <file src="$android_dir$/Microsoft.AppCenter.Distribute.Android.Bindings.dll" target="lib/MonoAndroid403" />
 
     <!-- iOS -->
     <file src="$ios_dir$/Microsoft.AppCenter.Distribute.dll" target="lib/Xamarin.iOS10" />
+    <file src="$ios_dir$/Microsoft.AppCenter.Distribute.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Distribute.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
   </files>

--- a/nuget/MacAppCenterPush.nuspec
+++ b/nuget/MacAppCenterPush.nuspec
@@ -39,16 +39,20 @@
 
     <!-- Portable -->
     <file src="$pcl_dir$/Microsoft.AppCenter.Push.dll" target="lib/portable-net45+win8+wpa81+wp8" />
+    <file src="$pcl_dir$/Microsoft.AppCenter.Push.xml" target="lib/portable-net45+win8+wpa81+wp8" />
 
     <!-- .NET Standard -->
     <file src="$netstandard_dir$/Microsoft.AppCenter.Push.dll" target="lib/netstandard1.0" />
+    <file src="$netstandard_dir$/Microsoft.AppCenter.Push.xml" target="lib/netstandard1.0" />
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Push.dll" target="lib/MonoAndroid403" />
+    <file src="$android_dir$/Microsoft.AppCenter.Push.xml" target="lib/MonoAndroid403" />
     <file src="$android_dir$/Microsoft.AppCenter.Push.Android.Bindings.dll" target="lib/MonoAndroid403" />
 
     <!-- iOS -->
     <file src="$ios_dir$/Microsoft.AppCenter.Push.dll" target="lib/Xamarin.iOS10" />
+    <file src="$ios_dir$/Microsoft.AppCenter.Push.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Push.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
   </files>

--- a/nuget/WindowsAppCenterCrashes.nuspec
+++ b/nuget/WindowsAppCenterCrashes.nuspec
@@ -28,19 +28,23 @@
     <!-- targets files add correct references to proper platforms -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.targets" target="build/uap10.0" />
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="ref/uap10.0" />
+    <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.xml" target="ref/uap10.0" />
 
     <!--x86 -->
     <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x86/lib/uap10.0" />
+    <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.xml" target="runtimes/win10-x86/lib/uap10.0" />
     <file src="$uwp_dir$/x86/WatsonRegistrationUtility.dll" target="runtimes/win10-x86/native"/>
     <file src="$uwp_dir$/x86/WatsonRegistrationUtility.winmd" target="runtimes/win10-x86/lib/uap10.0" />
 
     <!-- x64 -->
     <file src="$uwp_dir$/x64/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x64/lib/uap10.0" />
+    <file src="$uwp_dir$/x64/Microsoft.AppCenter.Crashes.xml" target="runtimes/win10-x64/lib/uap10.0" />
     <file src="$uwp_dir$/x64/WatsonRegistrationUtility.dll" target="runtimes/win10-x64/native"/>
     <file src="$uwp_dir$/x64/WatsonRegistrationUtility.winmd" target="runtimes/win10-x64/lib/uap10.0" />
 
     <!-- ARM -->
     <file src="$uwp_dir$/ARM/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-arm/lib/uap10.0" />
+    <file src="$uwp_dir$/ARM/Microsoft.AppCenter.Crashes.xml" target="runtimes/win10-arm/lib/uap10.0" />
     <file src="$uwp_dir$/ARM/WatsonRegistrationUtility.dll" target="runtimes/win10-arm/native"/>
     <file src="$uwp_dir$/ARM/WatsonRegistrationUtility.winmd" target="runtimes/win10-arm/lib/uap10.0" />
 

--- a/nuget/WindowsAppCenterPush.nuspec
+++ b/nuget/WindowsAppCenterPush.nuspec
@@ -20,5 +20,6 @@
   </metadata>
   <files>
     <file src="$uwp_dir$/Microsoft.AppCenter.Push.dll" target="lib/uap10.0" />
+    <file src="$uwp_dir$/Microsoft.AppCenter.Push.xml" target="lib/uap10.0" />
   </files>
 </package>

--- a/scripts/utility.cake
+++ b/scripts/utility.cake
@@ -29,10 +29,7 @@ void CopyFiles(IEnumerable<string> files, string targetDirectory, bool clean = t
     }
     foreach (var file in files)
     {
-        if (FileExists(file))
-        {
-            CopyFile(file, targetDirectory + "/" + System.IO.Path.GetFileName(file));
-        }
+        CopyFile(file, targetDirectory + "/" + System.IO.Path.GetFileName(file));
     }
 }
 

--- a/scripts/utility.cake
+++ b/scripts/utility.cake
@@ -29,7 +29,10 @@ void CopyFiles(IEnumerable<string> files, string targetDirectory, bool clean = t
     }
     foreach (var file in files)
     {
-        CopyFile(file, targetDirectory + "/" + System.IO.Path.GetFileName(file));
+        if (FileExists(file))
+        {
+            CopyFile(file, targetDirectory + "/" + System.IO.Path.GetFileName(file));
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The previous missed add reference to the xml files inside nuspec files of crash, distribute, push. Also 3 project files need to be update too.

## Related PRs or issues
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/827/
