### PR TITLE
fix crashes.xml not found error in release

### DIFF
--- a/nuget/AppCenterCrashes.nuspec
+++ b/nuget/AppCenterCrashes.nuspec
@@ -45,7 +45,6 @@
     <!-- targets files add correct references to proper platforms -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.targets" target="build/uap10.0"/>
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="ref/uap10.0" />
-    <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.xml" target="ref/uap10.0" />
 
     <!--x86 -->
     <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x86/lib/uap10.0" />

--- a/nuget/WindowsAppCenterCrashes.nuspec
+++ b/nuget/WindowsAppCenterCrashes.nuspec
@@ -28,7 +28,6 @@
     <!-- targets files add correct references to proper platforms -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.targets" target="build/uap10.0" />
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="ref/uap10.0" />
-    <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.xml" target="ref/uap10.0" />
 
     <!--x86 -->
     <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x86/lib/uap10.0" />


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The previous fix passed in build, but release process meet an cannot find Microsoft.AppCenter.Crashes.xml file issue, which I found it supposed to be generated by a target "ref/uap10.0" not exist in corresponding project file. So remove this one since does not seems the xml will be generated.

## Related PRs or issues
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/862

