### PR TITLE
fix the crashes module does not show intellisense

### DIFF
--- a/nuget/AppCenterCrashes.nuspec
+++ b/nuget/AppCenterCrashes.nuspec
@@ -31,10 +31,12 @@
 
     <!-- Android -->
     <file src="$android_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/MonoAndroid403" />
+    <file src="$android_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/MonoAndroid403" />
     <file src="$android_dir$/Microsoft.AppCenter.Crashes.Android.Bindings.dll" target="lib/MonoAndroid403" />
 
     <!-- iOS -->
     <file src="$ios_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/Xamarin.iOS10" />
+    <file src="$ios_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Crashes.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
     <!-- WindowsDesktop (WPF and WinForms) -->


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Observed the Crashes module still does not show intellisense in Android and iOS apps. 

Tried build on Mac machine, then everything is ok. But use the assemblies from remote feed still got this issue.

The root cause is that there are three nuspec files exists for Crashes:
- AppCenterCrashes.nuspec
- WindowsAppCenterCrashes.nuspec
- MacAppCenterCrashes.nuspec

As Ivan said, the windows one contain UWP targets which only can be build in windows, and Mac one only can be build on macOS. CI build them separately, then merge. Then the AppCenterCrashes.nuspec will be used as final nuget package's spec.

Currently, we have added the *DocumentationFile* tag for all targets inside the *Mac version's nuspec*, but did not add the *DocumentationFile* tag for Android and iOS target in the final one `AppCenterCrashes.nuspec`. So if this file used as a `Copy files list` for build script, then the next nuget pack cli will miss the xml files. Add tags into the final nuspec should fix this issue. 

## Related PRs or issues
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/862
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/865