### PR TITLE
fix intellisense for crashes uap10

### DIFF
--- a/nuget/AppCenterCrashes.nuspec
+++ b/nuget/AppCenterCrashes.nuspec
@@ -47,6 +47,7 @@
     <!-- targets files add correct references to proper platforms -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.targets" target="build/uap10.0"/>
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="ref/uap10.0" />
+    <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.xml" target="ref/uap10.0" />
 
     <!--x86 -->
     <file src="$uwp_dir$/x86/Microsoft.AppCenter.Crashes.dll" target="runtimes/win10-x86/lib/uap10.0" />


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The last intellisense issue for crashes module in target uap10 has an issue on CI server that cannot find the xml file at the same place as the dll, so use the same one from x86 child folder as confirmed locally.

## Related PRs or issues
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/862
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/865
https://github.com/Microsoft/AppCenter-SDK-DotNet/pull/867


