### PR TITLE
Bind Auth.OpenUrl on iOS

### DIFF
--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS.Bindings/ApiDefinition.cs
@@ -34,6 +34,11 @@ namespace Microsoft.AppCenter.Auth.iOS.Bindings
         [Static]
         [Export("signOut")]
         void SignOut();
+
+        // + (void)openURL:(NSURL *)url;
+        [Static]
+        [Export("openURL:")]
+        void OpenUrl(NSUrl url);
     }
 
     // typedef void (^MSSignInCompletionHandler)(MSUserInformation* _Nullable userInformation, NSError * _Nullable error);

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS.Bindings/Microsoft.AppCenter.Auth.iOS.Bindings.csproj
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS.Bindings/Microsoft.AppCenter.Auth.iOS.Bindings.csproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectTypeGuids>{8FFB629D-F513-41CE-95D2-7ECE97B6EEEC};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS/Auth.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS/Auth.cs
@@ -60,5 +60,15 @@ namespace Microsoft.AppCenter.Auth
         {
             MSIdentity.SignOut();
         }
+
+        /// <summary>
+        /// Process URL request for the Auth service.
+        /// Place this method call into app delegate openUrl method.
+        /// </summary>
+        /// <param name="url">The url with parameters.</param>
+        public static void OpenUrl(NSUrl url)
+        {
+            MSIdentity.OpenUrl(url);
+        }
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Manage that for Xamarin: https://review.docs.microsoft.com/en-us/appcenter/sdk/identity/ios?branch=pr-en-us-1152#disable-automatic-forwarding-of-your-application-delegates-methods-to-app-center-services

## Misc

Tested on ipad with iOS 9 by disabling swizzling.