### PR TITLE
Document utils now populate metadata even for documents with errors

### DIFF
--- a/SDK/AppCenterData/Microsoft.AppCenter.Data.iOS/ConversionExtensions.cs
+++ b/SDK/AppCenterData/Microsoft.AppCenter.Data.iOS/ConversionExtensions.cs
@@ -16,9 +16,7 @@ namespace Microsoft.AppCenter.Data
 
         public static DocumentWrapper<T> ToDocumentWrapper<T>(this MSDocumentWrapper documentWrapper)
         {
-            // We can not use JsonValue here - it contains not the document itself, but the whole MSDocumentWrapper serialized.
-            // TODO fix this when the native bug is fixed.
-            var deserializedValue = documentWrapper.DeserializedValue != null ? documentWrapper.DeserializedValue.ToDocument<T>() : default(T);
+            var deserializedValue = JsonConvert.DeserializeObject<T>(documentWrapper.JsonValue);
             return new DocumentWrapper<T>
             {
                 DeserializedValue = deserializedValue,

--- a/scripts/configuration/ac-build-config.xml
+++ b/scripts/configuration/ac-build-config.xml
@@ -2,7 +2,7 @@
 <config>
     <sdkInfo>
         <sdkVersion>2.0.0-SNAPSHOT</sdkVersion>
-        <iosVersion>2.0.0-218+a7b28c2c682518079e0e30db17de117c95dbf7c1</iosVersion>
+        <iosVersion>2.0.0-229+11fb5ee9b7f03d43d08b63ec5ddd92ce354f7870</iosVersion>
         <androidVersion>2.0.0-38+157a92bb6</androidVersion>
     </sdkInfo>
     <group id="ios" folder="iOSAssemblies" buildGroup="mac">


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The document utils changed to include metadata even when the document is malformed or missing.  This was prompted by a native SDK change.

## Related PRs or issues

https://github.com/Microsoft/AppCenter-SDK-Apple/pull/1561

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
