### PR TITLE
replace deprecated licenceUrl with licence element

### DIFF
--- a/nuget/AppCenter.nuspec
+++ b/nuget/AppCenter.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group targetFramework="uap10.0">

--- a/nuget/AppCenterAnalytics.nuspec
+++ b/nuget/AppCenterAnalytics.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter analytics mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/AppCenterAuth.nuspec
+++ b/nuget/AppCenterAuth.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter auth</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group>

--- a/nuget/AppCenterCrashes.nuspec
+++ b/nuget/AppCenterCrashes.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter crashes mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/AppCenterData.nuspec
+++ b/nuget/AppCenterData.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter data mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group>

--- a/nuget/AppCenterDistribute.nuspec
+++ b/nuget/AppCenterDistribute.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter distribute mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/AppCenterPush.nuspec
+++ b/nuget/AppCenterPush.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter push mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group>

--- a/nuget/AppCenterRum.nuspec
+++ b/nuget/AppCenterRum.nuspec
@@ -10,7 +10,7 @@
     <copyright>Copyright (c) Microsoft Corporation. All Rights Reserved.</copyright>
     <tags>mobilecenter</tags>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/MacAppCenter.nuspec
+++ b/nuget/MacAppCenter.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
         <!-- Use dependency groups for iOS and Android so that additional dependencies aren't added to them -->

--- a/nuget/MacAppCenterAnalytics.nuspec
+++ b/nuget/MacAppCenterAnalytics.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter analytics mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/MacAppCenterAuth.nuspec
+++ b/nuget/MacAppCenterAuth.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter auth</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group>

--- a/nuget/MacAppCenterCrashes.nuspec
+++ b/nuget/MacAppCenterCrashes.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter crashes mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/MacAppCenterData.nuspec
+++ b/nuget/MacAppCenterData.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter data mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group>

--- a/nuget/MacAppCenterDistribute.nuspec
+++ b/nuget/MacAppCenterDistribute.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter distribute mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/MacAppCenterPush.nuspec
+++ b/nuget/MacAppCenterPush.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter push mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group>

--- a/nuget/MacAppCenterRum.nuspec
+++ b/nuget/MacAppCenterRum.nuspec
@@ -10,7 +10,7 @@
     <copyright>Copyright (c) Microsoft Corporation. All Rights Reserved.</copyright>
     <tags>mobilecenter</tags>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/WindowsAppCenter.nuspec
+++ b/nuget/WindowsAppCenter.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <group targetFramework="uap10.0">

--- a/nuget/WindowsAppCenterAnalytics.nuspec
+++ b/nuget/WindowsAppCenterAnalytics.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter analytics mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/WindowsAppCenterCrashes.nuspec
+++ b/nuget/WindowsAppCenterCrashes.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter crashes mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/WindowsAppCenterPush.nuspec
+++ b/nuget/WindowsAppCenterPush.nuspec
@@ -12,7 +12,7 @@
     <tags>app center appcenter push mobilecenter</tags>
     <language>en-US</language>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />

--- a/nuget/WindowsAppCenterRum.nuspec
+++ b/nuget/WindowsAppCenterRum.nuspec
@@ -10,7 +10,7 @@
     <copyright>Copyright (c) Microsoft Corporation. All Rights Reserved.</copyright>
     <tags>mobilecenter</tags>
     <projectUrl>https://aka.ms/telgml</projectUrl>
-    <licenseUrl>https://aka.ms/vbgfx2</licenseUrl>
+    <license type="expression">MIT</license>
     <iconUrl>https://aka.ms/k76877</iconUrl>
     <dependencies>
       <dependency id="Microsoft.AppCenter" version="$version$" />


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The `licenceUrl` element is deprecated in *.nuspec files. Updated to use recommend `licence` element.


