### PR TITLE
UserInformation init does not need to be public anymore

### DIFF
--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Shared/UserInformation.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Shared/UserInformation.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AppCenter.Auth
         /// <param name="accountId">Account identifier.</param>
         /// <param name="accessToken">Access token.</param>
         /// <param name="idToken">Identifier token.</param>
-        public UserInformation(string accountId, string accessToken, string idToken)
+        internal UserInformation(string accountId, string accessToken, string idToken)
         {
             AccountId = accountId;
             AccessToken = accessToken;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

UserInformation init does not need to be public anymore since moved from core to auth