### PR TITLE
Enable packaging wpf/winforms dlls for core/crashes / avoid crash for unsupported modules at start

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/AppCenter.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AppCenter
         private const string NotConfiguredMessage = "App Center hasn't been configured. " +
                                                     "You need to call AppCenter.Start with appSecret or AppCenter.Configure first.";
         private const string ChannelName = "core";
-        private const string DistributeServiceFullType = "Microsoft.AppCenter.Distribute.Distribute";
 
         // The lock is static. Instance methods are not necessarily thread safe, but static methods are
         private static readonly object AppCenterLock = new object();
@@ -216,7 +215,7 @@ namespace Microsoft.AppCenter
                 }
             }
         }
- 
+
         // Atomically checks if the CorrelationId equals "testValue" and updates the value if true.
         // Returns "true" if value was changed. If not, the current value is assigned to setValue.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -371,21 +370,13 @@ namespace Microsoft.AppCenter
                 }
                 try
                 {
-                    // We don't support distribute in UWP, not even a custom start.
-                    if (IsDistributeService(serviceType))
+                    var serviceInstance = serviceType.GetRuntimeProperty("Instance")?.GetValue(null) as IAppCenterService;
+                    if (serviceInstance == null)
                     {
-                        AppCenterLog.Warn(AppCenterLog.LogTag, "Distribute service is not yet supported on UWP.");
+                        throw new AppCenterException("Service type does not contain static 'Instance' property of type IAppCenterService. The service is either not an App Center service or it's unsupported on this platform or the SDK is used from a .NET standard library and the nuget was not also added to the UWP/WPF/WinForms project.");
                     }
-                    else
-                    {
-                        var serviceInstance = serviceType.GetRuntimeProperty("Instance")?.GetValue(null) as IAppCenterService;
-                        if (serviceInstance == null)
-                        {
-                            throw new AppCenterException("Service type does not contain static 'Instance' property of type IAppCenterService");
-                        }
-                        StartService(serviceInstance);
-                        serviceNames.Add(serviceInstance.ServiceName);
-                    }
+                    StartService(serviceInstance);
+                    serviceNames.Add(serviceInstance.ServiceName);
                 }
                 catch (AppCenterException e)
                 {
@@ -436,12 +427,6 @@ namespace Microsoft.AppCenter
         }
 
         internal Guid InstanceCorrelationId = Guid.Empty;
-
-        // We don't support Distribute in UWP.
-        private static bool IsDistributeService(Type serviceType)
-        {
-            return serviceType?.FullName == DistributeServiceFullType;
-        }
 
         #endregion
     }

--- a/SDK/AppCenter/Microsoft.AppCenter/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter/AppCenter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AppCenter
 
         /* Error message to display for unsupported targets. */
         const string ErrorMessage =
-            "[AppCenter] ASSERT: Cannot use App Center on this target. If you are on Android or iOS or UWP, you must add the NuGet packages in the Android and iOS and UWP projects as well. Other targets are not yet supported.";
+            "[AppCenter] ASSERT: Cannot use App Center on this target. If you use the SDK from a .NET standard library, you must also add the App Center NuGet packages in the Android, iOS and UWP/WPF/Winforms projects as well. Other targets are not yet supported.";
 
         static LogLevel PlatformLogLevel { get; set; }
 

--- a/SDK/AppCenter/Microsoft.AppCenter/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter/AppCenter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AppCenter
 
         /* Error message to display for unsupported targets. */
         const string ErrorMessage =
-            "[AppCenter] ASSERT: Cannot use App Center on this target. If you use the SDK from a .NET standard library, you must also add the App Center NuGet packages in the Android, iOS and UWP/WPF/Winforms projects as well. Other targets are not yet supported.";
+            "[AppCenter] ASSERT: Cannot use App Center on this target. If you are using the SDK from a .NET standard library, you must also add the App Center NuGet packages in the Android, iOS and UWP/WPF/WinForms projects as well. Other targets are not yet supported.";
 
         static LogLevel PlatformLogLevel { get; set; }
 

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Analytics.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Analytics.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Analytics
 {
-    public class Analytics : AppCenterService
+    public partial class Analytics : AppCenterService
     {
         #region static
 

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Analytics.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Windows.Shared/Analytics.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Analytics
 {
-    public partial class Analytics : AppCenterService
+    public class Analytics : AppCenterService
     {
         #region static
 

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Analytics.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Analytics.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AppCenter.Analytics
     /// <summary>
     ///     Analytics feature.
     /// </summary>
-    public partial class Analytics
+    public class Analytics
     {
         private Analytics()
         {

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Analytics.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Analytics.cs
@@ -6,11 +6,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Analytics
 {
-    /// <inheritdoc />
     /// <summary>
     ///     Analytics feature.
     /// </summary>
-    public class Analytics : IAppCenterService
+    public partial class Analytics
     {
         private Analytics()
         {

--- a/nuget/AppCenter.nuspec
+++ b/nuget/AppCenter.nuspec
@@ -54,8 +54,7 @@
     <file src="$uwp_dir$/Microsoft.AppCenter.xml" target="lib/uap10.0" />
 
     <!-- Windows Classic Desktop (WPF and WinForms) -->
-    <!-- TODO: Uncomment when it's time to release these. -->
-    <!--file src="$windows_desktop_dir$/Microsoft.AppCenter.dll" target="lib/net45" /-->
-    <!--file src="$windows_desktop_dir$/Microsoft.AppCenter.xml" target="lib/net45" /-->
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.dll" target="lib/net45" />
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.xml" target="lib/net45" />
   </files>
 </package>

--- a/nuget/AppCenterCrashes.nuspec
+++ b/nuget/AppCenterCrashes.nuspec
@@ -35,12 +35,12 @@
     <file src="$ios_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/Xamarin.iOS10" />
     <file src="$ios_dir$/Microsoft.AppCenter.Crashes.iOS.Bindings.dll" target="lib/Xamarin.iOS10" />
 
-    <!-- WindowsDesktop (WPF and WinForms) -->
-    <!-- TODO: Uncomment when it's time to release these. -->
-    <!-- file src="$windows_desktop_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/net45" /-->
-
     <!-- UWP -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/uap10.0" />
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/uap10.0" />
+
+    <!-- WindowsDesktop (WPF and WinForms) -->
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/net45" />
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/net45" />
   </files>
 </package>

--- a/nuget/WindowsAppCenter.nuspec
+++ b/nuget/WindowsAppCenter.nuspec
@@ -27,11 +27,13 @@
     </dependencies>
   </metadata>
   <files>
+
+    <!-- UWP -->
     <file src="$uwp_dir$/Microsoft.AppCenter.dll" target="lib/uap10.0" />
     <file src="$uwp_dir$/Microsoft.AppCenter.xml" target="lib/uap10.0" />
 
-    <!-- TODO: Uncomment when it's time to release these. -->
-    <!-- file src="$windows_desktop_dir$/Microsoft.AppCenter.dll" target="lib/net45" /-->
-    <!-- file src="$windows_desktop_dir$/Microsoft.AppCenter.xml" target="lib/net45" /-->
+    <!-- WindowsDesktop (WPF and WinForms) -->
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.dll" target="lib/net45" />
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.xml" target="lib/net45" />
   </files>
 </package>

--- a/nuget/WindowsAppCenterCrashes.nuspec
+++ b/nuget/WindowsAppCenterCrashes.nuspec
@@ -20,11 +20,12 @@
   </metadata>
   <files>
 
-    <!-- WinForms -->
-    <!-- TODO: Uncomment when it's time to release these. -->
-    <!--file src="$windows_desktop_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/net45" /-->
-
     <!-- UWP -->
     <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/uap10.0" />
+    <file src="$uwp_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/uap10.0" />
+
+    <!-- WindowsDesktop (WPF and WinForms) -->
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.Crashes.dll" target="lib/net45" />
+    <file src="$windows_desktop_dir$/Microsoft.AppCenter.Crashes.xml" target="lib/net45" />
   </files>
 </package>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Enable packaging wpf/winforms dlls for core/crashes.

## Related PRs or issues

[AB#62888](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/62888)