### PR TITLE
Fix sending HTTP logs from windows desktop apps

### DIFF
--- a/AppCenter-Windows.sln
+++ b/AppCenter-Windows.sln
@@ -37,7 +37,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AppCenter.Crashes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Contoso.Forms.Puppet", "Contoso.Forms.Puppet", "{AC1B688C-2519-4C40-9F23-D4021C30E115}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contoso.Forms.Puppet", "Apps\Contoso.Forms.Puppet\Contoso.Forms.Puppet\Contoso.Forms.Puppet.csproj", "{92313C69-3BC4-4276-A1C8-100C86183F12}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contoso.Forms.Puppet", "Apps\Contoso.Forms.Puppet\Contoso.Forms.Puppet\Contoso.Forms.Puppet.csproj", "{92313C69-3BC4-4276-A1C8-100C86183F12}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contoso.Forms.Puppet.UWP", "Apps\Contoso.Forms.Puppet\Contoso.Forms.Puppet.UWP\Contoso.Forms.Puppet.UWP.csproj", "{F2E21B65-DF87-40F0-BB2E-E67E728B86DA}"
 EndProject
@@ -126,6 +126,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AppCenter.Data", "SDK\AppCenterData\Microsoft.AppCenter.Data\Microsoft.AppCenter.Data.csproj", "{0043E55C-F25A-4925-B558-7CFD141834E7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AppCenter.Crashes.Test.Windows", "Tests\Microsoft.AppCenter.Crashes.Test.Windows\Microsoft.AppCenter.Crashes.Test.Windows.csproj", "{1F1DBE94-AAEE-4A43-8586-EF8743672587}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AppCenter.Test.WindowsDesktop", "Tests\Microsoft.AppCenter.Test.WindowsDesktop\Microsoft.AppCenter.Test.WindowsDesktop.csproj", "{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -961,6 +963,30 @@ Global
 		{1F1DBE94-AAEE-4A43-8586-EF8743672587}.Release|x64.Build.0 = Release|Any CPU
 		{1F1DBE94-AAEE-4A43-8586-EF8743672587}.Release|x86.ActiveCfg = Release|Any CPU
 		{1F1DBE94-AAEE-4A43-8586-EF8743672587}.Release|x86.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|ARM.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhone.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x64.Build.0 = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1025,6 +1051,7 @@ Global
 		{F707D6CC-E43A-442F-AA38-B913EAE3D7C1} = {5BC8C674-8474-4C49-B1E4-DA4C70E86322}
 		{0043E55C-F25A-4925-B558-7CFD141834E7} = {5BC8C674-8474-4C49-B1E4-DA4C70E86322}
 		{1F1DBE94-AAEE-4A43-8586-EF8743672587} = {BC900C35-E0AD-46D2-BA4A-EF1904820B4A}
+		{C4674357-EFBA-43AA-9DB8-DE62A3309EB6} = {BC900C35-E0AD-46D2-BA4A-EF1904820B4A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {328868E2-F749-412D-B82F-84A683A1719C}

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Ingestion.Http
 {
-    public sealed class HttpNetworkAdapter : IHttpNetworkAdapter
+    public sealed partial class HttpNetworkAdapter : IHttpNetworkAdapter
     {
         internal const string ContentTypeValue = "application/json; charset=utf-8";
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+namespace Microsoft.AppCenter.Ingestion.Http
+{
+    /// <inheritdoc />
+    public sealed partial class HttpNetworkAdapter
+    {
+        // Static initializer specific to windows desktop platforms.
+        static HttpNetworkAdapter()
+        {
+            // ReSharper disable once InvertIf
+            if ((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls12) != SecurityProtocolType.Tls12)
+            {
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+                AppCenterLog.Debug(AppCenterLog.LogTag, "Enabled TLS 1.2 explicitly as it was disabled.");
+            }
+        }
+    }
+}

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
@@ -11,6 +11,11 @@ namespace Microsoft.AppCenter.Ingestion.Http
         // Static initializer specific to windows desktop platforms.
         static HttpNetworkAdapter()
         {
+            EnableTls12();
+        }
+
+        internal static void EnableTls12()
+        {
             // ReSharper disable once InvertIf
             if ((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls12) != SecurityProtocolType.Tls12)
             {

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Microsoft.AppCenter.WindowsDesktop.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Microsoft.AppCenter.WindowsDesktop.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Ingestion\Http\HttpNetworkAdapter.cs" />
     <Compile Include="Ingestion\Http\NetworkStateAdapter.cs" />
     <Compile Include="AppCenterPart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Ingestion/Http/HttpNetworkAdapterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Ingestion/Http/HttpNetworkAdapterTest.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AppCenter.Ingestion.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+
+namespace Microsoft.AppCenter.Test.WindowsDesktop.Ingestion.Http
+{
+    [TestClass]
+    public class HttpNetworkAdapterTest
+    {
+        [TestMethod]
+        public void EnableTls12WhenDisabled()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11;
+            HttpNetworkAdapter.EnableTls12();
+
+            // Check protocol was added, not the whole value overridden.
+            Assert.AreEqual(SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12, ServicePointManager.SecurityProtocol);
+        }
+
+        [TestMethod]
+        public void EnableTls12WhenAlreadyEnabled()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            HttpNetworkAdapter.EnableTls12();
+
+            // Just check no side effect.
+            Assert.AreEqual(SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12, ServicePointManager.SecurityProtocol);
+        }
+    }
+}

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Microsoft.AppCenter.Test.WindowsDesktop.csproj
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Microsoft.AppCenter.Test.WindowsDesktop.csproj
@@ -68,7 +68,6 @@
       <Name>Microsoft.AppCenter.WindowsDesktop</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Microsoft.AppCenter.Test.WindowsDesktop.csproj
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Microsoft.AppCenter.Test.WindowsDesktop.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppCenterTest.cs" />
+    <Compile Include="Ingestion\Http\HttpNetworkAdapterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\ApplicationSettingsTest.cs" />
     <Compile Include="Utils\DeviceInformationHelperTest.cs" />
@@ -67,6 +68,7 @@
       <Name>Microsoft.AppCenter.WindowsDesktop</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix sending HTTP logs from windows desktop apps by making sure TLS1.2 is enabled.

## Related PRs or issues

[AB#63054](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63054)

## Misc

It is not possible to enable the setting per http client unfortunately, it's a global state.
