### PR TITLE
Add same crash buttons in WPF puppet as Xamarin.Forms app

### DIFF
--- a/Apps/Contoso.WPF.Demo/App.xaml
+++ b/Apps/Contoso.WPF.Demo/App.xaml
@@ -1,9 +1,6 @@
 ﻿<Application x:Class="Contoso.WPF.Demo.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:Contoso.WPF.Demo"
              StartupUri="MainWindow.xaml">
-    <Application.Resources>
-         
-    </Application.Resources>
+    <Application.Resources/>
 </Application>

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -11,7 +11,7 @@ namespace Contoso.WPF.Demo
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
-    public partial class App : Application
+    public partial class App
     {
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml
@@ -7,17 +7,16 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:Contoso.WPF.Demo"
         mc:Ignorable="d"
         Title="App Center WPF Demo App" Height="257.794" Width="335">
     <StackPanel>
         <TabControl SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="App Center">
                 <StackPanel>
-                    <CheckBox Name="appCenterEnabled" Content="App Center Enabled" Margin="0,10,0,10" Checked="appCenterEnabled_Checked" Unchecked="appCenterEnabled_Checked"/>
+                    <CheckBox Name="AppCenterEnabled" Content="App Center Enabled" Margin="0,10,0,10" Checked="AppCenterEnabled_Checked" Unchecked="AppCenterEnabled_Checked"/>
                     <StackPanel Orientation ="Horizontal" HorizontalAlignment="Right" >
                         <Label Content="Log Level"/>
-                        <ComboBox Name="appCenterLogLevel" Width="200" SelectionChanged="appCenterLogLevel_SelectionChanged">
+                        <ComboBox Name="AppCenterLogLevel" Width="200" SelectionChanged="AppCenterLogLevel_SelectionChanged">
                             <ComboBoxItem Content="Verbose"/>
                             <ComboBoxItem Content="Debug"/>
                             <ComboBoxItem Content="Info"/>
@@ -42,9 +41,9 @@
                             <Label Content="Log Message" Grid.Column="0" Grid.Row="1"/>
                             <Label Content="Log Level" Grid.Column="0" Grid.Row="2"/>
 
-                            <TextBox Name="logTag" Grid.Column="1" Grid.Row="0" Margin="2"/>
-                            <TextBox Name="logMessage" Grid.Column="1" Grid.Row="1" Margin="2"/>
-                            <ComboBox Name="logLevel" Grid.Column="1" Grid.Row="2" Margin="2">
+                            <TextBox Name="LogTag" Grid.Column="1" Grid.Row="0" Margin="2"/>
+                            <TextBox Name="LogMessage" Grid.Column="1" Grid.Row="1" Margin="2"/>
+                            <ComboBox Name="LogLevel" Grid.Column="1" Grid.Row="2" Margin="2">
                                 <ComboBoxItem Content="Verbose"/>
                                 <ComboBoxItem Content="Debug"/>
                                 <ComboBoxItem Content="Info"/>
@@ -52,7 +51,7 @@
                                 <ComboBoxItem Content="Error"/>
                             </ComboBox>
 
-                            <Button Name="writeLog" Content="Write Log" Grid.ColumnSpan="2"  Grid.Row="3" Margin="2" Click="writeLog_Click"/>
+                            <Button Name="WriteLog" Content="Write Log" Grid.ColumnSpan="2"  Grid.Row="3" Margin="2" Click="WriteLog_Click"/>
                         </Grid>
 
                     </GroupBox>
@@ -61,20 +60,20 @@
             </TabItem>
             <TabItem Header="Analytics">
                 <StackPanel>
-                    <CheckBox Name="analyticsEnabled" Content="Analytics Enabled" Margin="0,10,0,10" Checked="analyticsEnabled_Checked" Unchecked="analyticsEnabled_Checked"/>
+                    <CheckBox Name="AnalyticsEnabled" Content="Analytics Enabled" Margin="0,10,0,10" Checked="AnalyticsEnabled_Checked" Unchecked="AnalyticsEnabled_Checked"/>
                     <GroupBox Header="Event">
                         <StackPanel Orientation="Vertical">
                             <DockPanel LastChildFill="True">
                                 <Label Content="Event Name"/>
-                                <TextBox Name="eventName" VerticalAlignment="Center" />
+                                <TextBox Name="EventName" VerticalAlignment="Center" />
                             </DockPanel>
-                            <DataGrid Name="eventProperties" AutoGenerateColumns="False" CanUserAddRows="True" MinHeight="60" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto" SelectionMode="Single" Margin="0,10,0,10">
+                            <DataGrid Name="EventProperties" AutoGenerateColumns="False" CanUserAddRows="True" MinHeight="60" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto" SelectionMode="Single" Margin="0,10,0,10">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Property Key" Width="*" Binding="{Binding Key}"/>
                                     <DataGridTextColumn Header="Property Value" Width="*" Binding="{Binding Value}"/>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <Button Name="trackEvent" Content="Track event" Click="trackEvent_Click"/>
+                            <Button Name="TrackEvent" Content="Track event" Click="TrackEvent_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
@@ -82,8 +81,14 @@
             <TabItem Header="Crashes">
                 <StackPanel>
                     <GroupBox Header="Crash">
-                        <StackPanel Orientation="Vertical">
-                            <Button Name="CrashWithNullReference" Content="Crash with NullReferenceException" Click="CrashWithNullReference_Click"/>
+                        <StackPanel Orientation="Vertical" Margin="2">
+                            <CheckBox Name="CrashesEnabled" Content="Crashes Enabled" Margin="0,10,0,10" Checked="CrashesEnabled_Checked" Unchecked="CrashesEnabled_Checked" />
+                            <Button Content="Call Crashes.GenerateTestCrash (debug only)" Margin="2" Click="CrashWithTestException_Click"/>
+                            <Button Content="Generate non serializable Exception" Margin="2" Click="CrashWithNonSerializableException_Click" />
+                            <Button Content="Divide by zero" Margin="2" Click="CrashWithDivisionByZero_Click" />
+                            <Button Content="Aggregate Exception" Margin="2" Click="CrashWithAggregateException_Click" />
+                            <Button Content="Crash with null reference" Margin="2" Click="CrashWithNullReference_Click"/>
+                            <Button Content="Async task crash" Margin="2" Click="CrashInsideAsyncTask_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="App Center WPF Demo App" Height="257.794" Width="335">
+        Title="App Center WPF Demo App" Height="300" Width="335">
     <StackPanel>
         <TabControl SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="App Center">

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
@@ -4,26 +4,31 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
-
+using Microsoft.AppCenter.Crashes;
 
 namespace Contoso.WPF.Demo
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    // ReSharper disable once UnusedMember.Global
+    public partial class MainWindow
     {
-        private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions = new Dictionary<LogLevel, Action<string, string>> {
-            { LogLevel.Verbose, AppCenterLog.Verbose },
-            { LogLevel.Debug, AppCenterLog.Debug },
-            { LogLevel.Info, AppCenterLog.Info },
-            { LogLevel.Warn, AppCenterLog.Warn },
-            { LogLevel.Error, AppCenterLog.Error }
-        };
+        private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions =
+            new Dictionary<LogLevel, Action<string, string>>
+            {
+                {Microsoft.AppCenter.LogLevel.Verbose, AppCenterLog.Verbose},
+                {Microsoft.AppCenter.LogLevel.Debug, AppCenterLog.Debug},
+                {Microsoft.AppCenter.LogLevel.Info, AppCenterLog.Info},
+                {Microsoft.AppCenter.LogLevel.Warn, AppCenterLog.Warn},
+                {Microsoft.AppCenter.LogLevel.Error, AppCenterLog.Error}
+            };
 
         public ObservableCollection<Property> Properties = new ObservableCollection<Property>();
 
@@ -31,35 +36,35 @@ namespace Contoso.WPF.Demo
         {
             InitializeComponent();
             UpdateState();
-            appCenterLogLevel.SelectedIndex = (int) AppCenter.LogLevel;
-            eventProperties.ItemsSource = Properties;
+            AppCenterLogLevel.SelectedIndex = (int) AppCenter.LogLevel;
+            EventProperties.ItemsSource = Properties;
         }
 
         private void UpdateState()
         {
-            appCenterEnabled.IsChecked = AppCenter.IsEnabledAsync().Result;
-            analyticsEnabled.IsChecked = Analytics.IsEnabledAsync().Result;
+            AppCenterEnabled.IsChecked = AppCenter.IsEnabledAsync().Result;
+            AnalyticsEnabled.IsChecked = Analytics.IsEnabledAsync().Result;
         }
 
-        private void appCenterEnabled_Checked(object sender, RoutedEventArgs e)
+        private void AppCenterEnabled_Checked(object sender, RoutedEventArgs e)
         {
-            if (appCenterEnabled.IsChecked.HasValue)
+            if (AppCenterEnabled.IsChecked.HasValue)
             {
-                AppCenter.SetEnabledAsync(appCenterEnabled.IsChecked.Value).Wait();
+                AppCenter.SetEnabledAsync(AppCenterEnabled.IsChecked.Value).Wait();
             }
         }
 
-        private void analyticsEnabled_Checked(object sender, RoutedEventArgs e)
+        private void AnalyticsEnabled_Checked(object sender, RoutedEventArgs e)
         {
-            if (analyticsEnabled.IsChecked.HasValue)
+            if (AnalyticsEnabled.IsChecked.HasValue)
             {
-                Analytics.SetEnabledAsync(analyticsEnabled.IsChecked.Value).Wait();
+                Analytics.SetEnabledAsync(AnalyticsEnabled.IsChecked.Value).Wait();
             }
         }
 
-        private void appCenterLogLevel_SelectionChanged(object sender, RoutedEventArgs e)
+        private void AppCenterLogLevel_SelectionChanged(object sender, RoutedEventArgs e)
         {
-            AppCenter.LogLevel = (LogLevel) appCenterLogLevel.SelectedIndex;
+            AppCenter.LogLevel = (LogLevel) AppCenterLogLevel.SelectedIndex;
         }
 
         private void TabControl_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -67,24 +72,95 @@ namespace Contoso.WPF.Demo
             UpdateState();
         }
 
-        private void writeLog_Click(object sender, RoutedEventArgs e)
+        private void WriteLog_Click(object sender, RoutedEventArgs e)
         {
-            if (logLevel.SelectedIndex == -1)
+            if (LogLevel.SelectedIndex == -1)
             {
                 return;
             }
-            var level = (LogLevel) logLevel.SelectedIndex;
-            var tag = logTag.Text;
-            var message = logMessage.Text;
+
+            var level = (LogLevel) LogLevel.SelectedIndex;
+            var tag = LogTag.Text;
+            var message = LogMessage.Text;
             LogFunctions[level](tag, message);
         }
 
-        private void trackEvent_Click(object sender, RoutedEventArgs e)
+        private void TrackEvent_Click(object sender, RoutedEventArgs e)
         {
-            var name = eventName.Text;
+            var name = EventName.Text;
             var propertiesDictionary = Properties.Where(property => property.Key != null && property.Value != null)
-                                                 .ToDictionary(property => property.Key, property => property.Value);
+                .ToDictionary(property => property.Key, property => property.Value);
             Analytics.TrackEvent(name, propertiesDictionary);
+        }
+
+        #region Crash
+
+        private void CrashesEnabled_Checked(object sender, RoutedEventArgs e)
+        {
+            if (CrashesEnabled.IsChecked.HasValue)
+            {
+                Crashes.SetEnabledAsync(CrashesEnabled.IsChecked.Value).Wait();
+            }
+        }
+
+        public class NonSerializableException : Exception
+        {
+        }
+
+        private void CrashWithTestException_Click(object sender, RoutedEventArgs e)
+        {
+            Crashes.GenerateTestCrash();
+        }
+
+        private void CrashWithNonSerializableException_Click(object sender, RoutedEventArgs e)
+        {
+            throw new NonSerializableException();
+        }
+
+        private void CrashWithDivisionByZero_Click(object sender, RoutedEventArgs e)
+        {
+            _ = 42 / int.Parse("0");
+        }
+
+        private void CrashWithAggregateException_Click(object sender, RoutedEventArgs e)
+        {
+            throw GenerateAggregateException();
+        }
+
+        private static Exception GenerateAggregateException()
+        {
+            try
+            {
+                throw new AggregateException(SendHttp(), new ArgumentException("Invalid parameter", ValidateLength()));
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+        }
+
+        private static Exception SendHttp()
+        {
+            try
+            {
+                throw new IOException("Network down");
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+        }
+
+        private static Exception ValidateLength()
+        {
+            try
+            {
+                throw new ArgumentOutOfRangeException(null, "It's over 9000!");
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
         }
 
         private void CrashWithNullReference_Click(object sender, RoutedEventArgs e)
@@ -93,5 +169,20 @@ namespace Contoso.WPF.Demo
             var b = values[1].Trim();
             System.Diagnostics.Debug.WriteLine(b);
         }
+
+        private async void CrashInsideAsyncTask_Click(object sender, RoutedEventArgs e)
+        {
+            await FakeService.DoStuffInBackground();
+        }
+
+        private static class FakeService
+        {
+            public static async Task DoStuffInBackground()
+            {
+                await Task.Run(() => throw new IOException("Server did not respond"));
+            }
+        }
+
+        #endregion
     }
 }

--- a/Apps/Contoso.WPF.Puppet/App.xaml
+++ b/Apps/Contoso.WPF.Puppet/App.xaml
@@ -1,9 +1,6 @@
 ﻿<Application x:Class="Contoso.WPF.Puppet.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:Contoso.WPF.Puppet"
              StartupUri="MainWindow.xaml">
-    <Application.Resources>
-         
-    </Application.Resources>
+    <Application.Resources/>
 </Application>

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -11,7 +11,7 @@ namespace Contoso.WPF.Puppet
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
-    public partial class App : Application
+    public partial class App
     {
         protected override void OnStartup(StartupEventArgs e)
         {

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -13,10 +13,10 @@
         <TabControl SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="App Center">
                 <StackPanel>
-                    <CheckBox Name="appCenterEnabled" Content="App Center Enabled" Margin="0,10,0,10" Checked="appCenterEnabled_Checked" Unchecked="appCenterEnabled_Checked"/>
+                    <CheckBox Name="AppCenterEnabled" Content="App Center Enabled" Margin="0,10,0,10" Checked="AppCenterEnabled_Checked" Unchecked="AppCenterEnabled_Checked"/>
                     <StackPanel Orientation ="Horizontal" HorizontalAlignment="Right" >
                         <Label Content="Log Level"/>
-                        <ComboBox Name="appCenterLogLevel" Width="200" SelectionChanged="appCenterLogLevel_SelectionChanged">
+                        <ComboBox Name="AppCenterLogLevel" Width="200" SelectionChanged="AppCenterLogLevel_SelectionChanged">
                             <ComboBoxItem Content="Verbose"/>
                             <ComboBoxItem Content="Debug"/>
                             <ComboBoxItem Content="Info"/>
@@ -41,9 +41,9 @@
                             <Label Content="Log Message" Grid.Column="0" Grid.Row="1"/>
                             <Label Content="Log Level" Grid.Column="0" Grid.Row="2"/>
 
-                            <TextBox Name="logTag" Grid.Column="1" Grid.Row="0" Margin="2"/>
-                            <TextBox Name="logMessage" Grid.Column="1" Grid.Row="1" Margin="2"/>
-                            <ComboBox Name="logLevel" Grid.Column="1" Grid.Row="2" Margin="2">
+                            <TextBox Name="LogTag" Grid.Column="1" Grid.Row="0" Margin="2"/>
+                            <TextBox Name="LogMessage" Grid.Column="1" Grid.Row="1" Margin="2"/>
+                            <ComboBox Name="LogLevel" Grid.Column="1" Grid.Row="2" Margin="2">
                                 <ComboBoxItem Content="Verbose"/>
                                 <ComboBoxItem Content="Debug"/>
                                 <ComboBoxItem Content="Info"/>
@@ -51,7 +51,7 @@
                                 <ComboBoxItem Content="Error"/>
                             </ComboBox>
 
-                            <Button Name="writeLog" Content="Write Log" Grid.ColumnSpan="2"  Grid.Row="3" Margin="2" Click="writeLog_Click"/>
+                            <Button Name="WriteLog" Content="Write Log" Grid.ColumnSpan="2"  Grid.Row="3" Margin="2" Click="WriteLog_Click"/>
                         </Grid>
 
                     </GroupBox>
@@ -60,20 +60,20 @@
             </TabItem>
             <TabItem Header="Analytics">
                 <StackPanel>
-                    <CheckBox Name="analyticsEnabled" Content="Analytics Enabled" Margin="0,10,0,10" Checked="analyticsEnabled_Checked" Unchecked="analyticsEnabled_Checked"/>
+                    <CheckBox Name="AnalyticsEnabled" Content="Analytics Enabled" Margin="0,10,0,10" Checked="AnalyticsEnabled_Checked" Unchecked="AnalyticsEnabled_Checked"/>
                     <GroupBox Header="Event">
                         <StackPanel Orientation="Vertical">
                             <DockPanel LastChildFill="True">
                                 <Label Content="Event Name"/>
                                 <TextBox Name="eventName" VerticalAlignment="Center" />
                             </DockPanel>
-                            <DataGrid Name="eventProperties" AutoGenerateColumns="False" CanUserAddRows="True" MinHeight="60" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto" SelectionMode="Single" Margin="0,10,0,10">
+                            <DataGrid Name="EventProperties" AutoGenerateColumns="False" CanUserAddRows="True" MinHeight="60" HorizontalAlignment="Stretch" VerticalScrollBarVisibility="Auto" SelectionMode="Single" Margin="0,10,0,10">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Property Key" Width="*" Binding="{Binding Key}"/>
                                     <DataGridTextColumn Header="Property Value" Width="*" Binding="{Binding Value}"/>
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <Button Name="trackEvent" Content="Track event" Click="trackEvent_Click"/>
+                            <Button Name="TrackEvent" Content="Track event" Click="TrackEvent_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
@@ -82,13 +82,12 @@
                 <StackPanel>
                     <GroupBox Header="Crash">
                         <StackPanel Orientation="Vertical" Margin="2">
-                            <CheckBox Name="crashesEnabled" Content="Crashes Enabled" Margin="0,10,0,10" Checked="crashesEnabled_Checked" Unchecked="crashesEnabled_Checked" />
+                            <CheckBox Name="CrashesEnabled" Content="Crashes Enabled" Margin="0,10,0,10" Checked="CrashesEnabled_Checked" Unchecked="CrashesEnabled_Checked" />
                             <Button Content="Call Crashes.GenerateTestCrash (debug only)" Margin="2" Click="CrashWithTestException_Click"/>
                             <Button Content="Generate non serializable Exception" Margin="2" Click="CrashWithNonSerializableException_Click" />
                             <Button Content="Divide by zero" Margin="2" Click="CrashWithDivisionByZero_Click" />
                             <Button Content="Aggregate Exception" Margin="2" Click="CrashWithAggregateException_Click" />
                             <Button Content="Crash with null reference" Margin="2" Click="CrashWithNullReference_Click"/>
-                            <Button Content="Stackoverflow exception" Margin="2" Click="StackOverflow_Click"/>
                             <Button Content="Async task crash" Margin="2" Click="CrashInsideAsyncTask_Click"/>
                         </StackPanel>
                     </GroupBox>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="App Center WPF Puppet App" Height="257.794" Width="335">
+        Title="App Center WPF Puppet App" Height="300.078" Width="335">
     <StackPanel>
         <TabControl SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="App Center">
@@ -82,11 +82,13 @@
                 <StackPanel>
                     <GroupBox Header="Crash">
                         <StackPanel Orientation="Vertical" Margin="2">
+                            <CheckBox Name="crashesEnabled" Content="Crashes Enabled" Margin="0,10,0,10" Checked="crashesEnabled_Checked" Unchecked="crashesEnabled_Checked" />
                             <Button Content="Call Crashes.GenerateTestCrash (debug only)" Margin="2" Click="CrashWithTestException_Click"/>
                             <Button Content="Generate non serializable Exception" Margin="2" Click="CrashWithNonSerializableException_Click" />
                             <Button Content="Divide by zero" Margin="2" Click="CrashWithDivisionByZero_Click" />
                             <Button Content="Aggregate Exception" Margin="2" Click="CrashWithAggregateException_Click" />
                             <Button Content="Crash with null reference" Margin="2" Click="CrashWithNullReference_Click"/>
+                            <Button Content="Stackoverflow exception" Margin="2" Click="StackOverflow_Click"/>
                             <Button Content="Async task crash" Margin="2" Click="CrashInsideAsyncTask_Click"/>
                         </StackPanel>
                     </GroupBox>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -7,7 +7,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:Contoso.WPF.Puppet"
         mc:Ignorable="d"
         Title="App Center WPF Puppet App" Height="257.794" Width="335">
     <StackPanel>
@@ -82,8 +81,13 @@
             <TabItem Header="Crashes">
                 <StackPanel>
                     <GroupBox Header="Crash">
-                        <StackPanel Orientation="Vertical">
-                            <Button Name="CrashWithNullReference" Content="Crash with NullReferenceException" Click="CrashWithNullReference_Click"/>
+                        <StackPanel Orientation="Vertical" Margin="2">
+                            <Button Content="Call Crashes.GenerateTestCrash (debug only)" Margin="2" Click="CrashWithTestException_Click"/>
+                            <Button Content="Generate non serializable Exception" Margin="2" Click="CrashWithNonSerializableException_Click" />
+                            <Button Content="Divide by zero" Margin="2" Click="CrashWithDivisionByZero_Click" />
+                            <Button Content="Aggregate Exception" Margin="2" Click="CrashWithAggregateException_Click" />
+                            <Button Content="Crash with null reference" Margin="2" Click="CrashWithNullReference_Click"/>
+                            <Button Content="Async task crash" Margin="2" Click="CrashInsideAsyncTask_Click"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="App Center WPF Puppet App" Height="300.078" Width="335">
+        Title="App Center WPF Puppet App" Height="300" Width="335">
     <StackPanel>
         <TabControl SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="App Center">

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace Contoso.WPF.Puppet
         private void UpdateState()
         {
             appCenterEnabled.IsChecked = AppCenter.IsEnabledAsync().Result;
+            crashesEnabled.IsChecked = Crashes.IsEnabledAsync().Result;
             analyticsEnabled.IsChecked = Analytics.IsEnabledAsync().Result;
         }
 
@@ -176,6 +177,26 @@ namespace Contoso.WPF.Puppet
             }
         }
 
+        private void crashesEnabled_Checked(object sender, RoutedEventArgs e)
+        {
+            if (crashesEnabled.IsChecked.HasValue)
+            {
+                Crashes.SetEnabledAsync(crashesEnabled.IsChecked.Value).Wait();
+            }
+        }
+
+        public int val
+        {
+            get
+            {
+                return val;
+            }
+        }
+
+        private void StackOverflow_Click(object sender, RoutedEventArgs e)
+        {
+            int stackOverflowVar = val;
+        }
         #endregion
     }
 }

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
@@ -17,16 +17,17 @@ namespace Contoso.WPF.Puppet
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    // ReSharper disable once UnusedMember.Global
+    public partial class MainWindow
     {
         private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions =
             new Dictionary<LogLevel, Action<string, string>>
             {
-                {LogLevel.Verbose, AppCenterLog.Verbose},
-                {LogLevel.Debug, AppCenterLog.Debug},
-                {LogLevel.Info, AppCenterLog.Info},
-                {LogLevel.Warn, AppCenterLog.Warn},
-                {LogLevel.Error, AppCenterLog.Error}
+                {Microsoft.AppCenter.LogLevel.Verbose, AppCenterLog.Verbose},
+                {Microsoft.AppCenter.LogLevel.Debug, AppCenterLog.Debug},
+                {Microsoft.AppCenter.LogLevel.Info, AppCenterLog.Info},
+                {Microsoft.AppCenter.LogLevel.Warn, AppCenterLog.Warn},
+                {Microsoft.AppCenter.LogLevel.Error, AppCenterLog.Error}
             };
 
         public ObservableCollection<Property> Properties = new ObservableCollection<Property>();
@@ -35,38 +36,37 @@ namespace Contoso.WPF.Puppet
         {
             InitializeComponent();
             UpdateState();
-            appCenterLogLevel.SelectedIndex = (int)AppCenter.LogLevel;
-            eventProperties.ItemsSource = Properties;
+            AppCenterLogLevel.SelectedIndex = (int)AppCenter.LogLevel;
+            EventProperties.ItemsSource = Properties;
         }
 
 
         private void UpdateState()
         {
-            appCenterEnabled.IsChecked = AppCenter.IsEnabledAsync().Result;
-            crashesEnabled.IsChecked = Crashes.IsEnabledAsync().Result;
-            analyticsEnabled.IsChecked = Analytics.IsEnabledAsync().Result;
+            AppCenterEnabled.IsChecked = AppCenter.IsEnabledAsync().Result;
+            CrashesEnabled.IsChecked = Crashes.IsEnabledAsync().Result;
+            AnalyticsEnabled.IsChecked = Analytics.IsEnabledAsync().Result;
         }
 
-        private void appCenterEnabled_Checked(object sender, RoutedEventArgs e)
+        private void AppCenterEnabled_Checked(object sender, RoutedEventArgs e)
         {
-            if (appCenterEnabled.IsChecked.HasValue)
+            if (AppCenterEnabled.IsChecked.HasValue)
             {
-                AppCenter.SetEnabledAsync(appCenterEnabled.IsChecked.Value).Wait();
+                AppCenter.SetEnabledAsync(AppCenterEnabled.IsChecked.Value).Wait();
             }
         }
 
-        private void analyticsEnabled_Checked(object sender, RoutedEventArgs e)
+        private void AnalyticsEnabled_Checked(object sender, RoutedEventArgs e)
         {
-            if (analyticsEnabled.IsChecked.HasValue)
+            if (AnalyticsEnabled.IsChecked.HasValue)
             {
-                Analytics.SetEnabledAsync(analyticsEnabled.IsChecked.Value).Wait();
+                Analytics.SetEnabledAsync(AnalyticsEnabled.IsChecked.Value).Wait();
             }
         }
 
-
-        private void appCenterLogLevel_SelectionChanged(object sender, RoutedEventArgs e)
+        private void AppCenterLogLevel_SelectionChanged(object sender, RoutedEventArgs e)
         {
-            AppCenter.LogLevel = (LogLevel)appCenterLogLevel.SelectedIndex;
+            AppCenter.LogLevel = (LogLevel)AppCenterLogLevel.SelectedIndex;
         }
 
         private void TabControl_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -74,20 +74,20 @@ namespace Contoso.WPF.Puppet
             UpdateState();
         }
 
-        private void writeLog_Click(object sender, RoutedEventArgs e)
+        private void WriteLog_Click(object sender, RoutedEventArgs e)
         {
-            if (logLevel.SelectedIndex == -1)
+            if (LogLevel.SelectedIndex == -1)
             {
                 return;
             }
 
-            var level = (LogLevel)logLevel.SelectedIndex;
-            var tag = logTag.Text;
-            var message = logMessage.Text;
+            var level = (LogLevel)LogLevel.SelectedIndex;
+            var tag = LogTag.Text;
+            var message = LogMessage.Text;
             LogFunctions[level](tag, message);
         }
 
-        private void trackEvent_Click(object sender, RoutedEventArgs e)
+        private void TrackEvent_Click(object sender, RoutedEventArgs e)
         {
             var name = eventName.Text;
             var propertiesDictionary = Properties.Where(property => property.Key != null && property.Value != null)
@@ -96,6 +96,14 @@ namespace Contoso.WPF.Puppet
         }
 
         #region Crash
+
+        private void CrashesEnabled_Checked(object sender, RoutedEventArgs e)
+        {
+            if (CrashesEnabled.IsChecked.HasValue)
+            {
+                Crashes.SetEnabledAsync(CrashesEnabled.IsChecked.Value).Wait();
+            }
+        }
 
         public class NonSerializableException : Exception
         {
@@ -177,26 +185,6 @@ namespace Contoso.WPF.Puppet
             }
         }
 
-        private void crashesEnabled_Checked(object sender, RoutedEventArgs e)
-        {
-            if (crashesEnabled.IsChecked.HasValue)
-            {
-                Crashes.SetEnabledAsync(crashesEnabled.IsChecked.Value).Wait();
-            }
-        }
-
-        public int val
-        {
-            get
-            {
-                return val;
-            }
-        }
-
-        private void StackOverflow_Click(object sender, RoutedEventArgs e)
-        {
-            int stackOverflowVar = val;
-        }
         #endregion
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add same crash buttons in WPF puppet as Xamarin.Forms app

## Related PRs or issues

[AB#62886](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/62886)