### PR TITLE
Feature/windows fix storage get logs

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AppCenter.Storage
 
         private readonly Dictionary<string, List<long>> _pendingDbIdentifierGroups = new Dictionary<string, List<long>>();
         private readonly HashSet<long> _pendingDbIdentifiers = new HashSet<long>();
+
         // Blocking collection is thread safe
         private readonly BlockingCollection<Task> _queue = new BlockingCollection<Task>();
         private readonly SemaphoreSlim _flushSemaphore = new SemaphoreSlim(0);
@@ -224,7 +225,7 @@ namespace Microsoft.AppCenter.Storage
                 var idPairs = new List<Tuple<Guid?, long>>();
                 var failedToDeserializeALog = false;
                 var retrievedEntries =
-                    _storageAdapter.GetAsync<LogEntry>(entry => entry.Channel == channelName, limit)
+                    _storageAdapter.GetAsync<LogEntry>(entry => entry.Channel == channelName && !_pendingDbIdentifiers.Contains(entry.Id), limit)
                         .GetAwaiter().GetResult();
                 foreach (var entry in retrievedEntries)
                 {

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
@@ -229,10 +229,6 @@ namespace Microsoft.AppCenter.Storage
                         .GetAwaiter().GetResult();
                 foreach (var entry in retrievedEntries)
                 {
-                    if (_pendingDbIdentifiers.Contains(entry.Id))
-                    {
-                        continue;
-                    }
                     try
                     {
                         var log = LogSerializer.DeserializeLog(entry.Log);

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that counting number of logs stored when there are no logs returns 0.
+        /// Verify that counting number of logs stored when there are no logs returns 0.
         /// </summary>
         [TestMethod]
         public void CountEmptyStorage()
@@ -32,7 +32,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that after adding 'n' logs, counting logs returns 'n'.
+        /// Verify that after adding 'n' logs, counting logs returns 'n'.
         /// </summary>
         [TestMethod]
         public void CountNonemptyStorage()
@@ -44,7 +44,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that storing a log and then retrieving it from storage does not alter the log.
+        /// Verify that storing a log and then retrieving it from storage does not alter the log.
         /// </summary>
         [TestMethod]
         public void PutOneLog()
@@ -58,7 +58,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that deleting all logs for a given channel does so.
+        /// Verify that deleting all logs for a given channel does so.
         /// </summary>
         [TestMethod]
         public void DeleteLogsNoBatchId()
@@ -70,7 +70,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that deleting a particular batch deletes exactly the number of logs for that batch.
+        /// Verify that deleting a particular batch deletes exactly the number of logs for that batch.
         /// </summary>
         [TestMethod]
         public void DeleteLogsWithBatchId()
@@ -86,7 +86,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that when the limit equals the number of logs for the given channel, all logs are returned.
+        /// Verify that when the limit equals the number of logs for the given channel, all logs are returned.
         /// </summary>
         [TestMethod]
         public void GetLogsExactLimit()
@@ -100,7 +100,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that when the limit is lower than the number of logs for the given channel, all logs are returned.
+        /// Verify that when the limit is lower than the number of logs for the given channel, all logs are returned.
         /// </summary>
         [TestMethod]
         public void GetLogsLowLimit()
@@ -115,7 +115,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that when the limit exceeds the number of logs for the given channel, 'limit' logs are correctly returned.
+        /// Verify that when the limit exceeds the number of logs for the given channel, 'limit' logs are correctly returned.
         /// </summary>
         [TestMethod]
         public void GetLogsHighLimit()
@@ -129,7 +129,29 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that when logs are retrieved, the batchId is not null.
+        /// Verify that when the limit is lower than the number of logs for the given channel, all logs are returned.
+        /// </summary>
+        [TestMethod]
+        public void GetLogsExcludesPendingLogsWithoutAffectingLimit()
+        {
+            var numLogsToAdd = 5;
+            var limit = 5;
+
+            // Add some logs and then retrieve them so they are marked as pending.
+            PutNLogs(numLogsToAdd);
+            _storage.GetLogsAsync(StorageTestChannelName, limit, new List<Log>()).RunNotAsync();
+            
+            // Add some new logs.
+            var addedLogs = PutNLogs(numLogsToAdd);
+            var retrievedLogs = new List<Log>();
+
+            //  Retrieve logs and make sure all of the new ones are returned, but not the pending logs.
+            _storage.GetLogsAsync(StorageTestChannelName, limit, retrievedLogs).RunNotAsync();
+            CollectionAssert.AreEquivalent(addedLogs, retrievedLogs);
+        }
+
+        /// <summary>
+        /// Verify that when logs are retrieved, the batchId is not null.
         /// </summary>
         [TestMethod]
         public void GetLogsHasBatchId()
@@ -143,7 +165,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that when no logs are retrieved, the batchId is null.
+        /// Verify that when no logs are retrieved, the batchId is null.
         /// </summary>
         [TestMethod]
         public void GetNoLogsHasNoBatchId()
@@ -157,7 +179,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that storage does not return same log more than once.
+        /// Verify that storage does not return same log more than once.
         /// </summary>
         [TestMethod]
         public void GetDuplicateLogs()
@@ -174,7 +196,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that a channel that starts with the name of another channel does not cause problems.
+        /// Verify that a channel that starts with the name of another channel does not cause problems.
         /// </summary>
         [TestMethod]
         public void GetLogsFromChannelWithSimilarNames()
@@ -187,7 +209,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that storage returns log more than once if pending state is cleared.
+        /// Verify that storage returns log more than once if pending state is cleared.
         /// </summary>
         [TestMethod]
         public void ClearPendingState()
@@ -205,7 +227,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        ///     Verify that an invalid log in the database, when retrieved, is deleted and no logs are returned.
+        /// Verify that an invalid log in the database, when retrieved, is deleted and no logs are returned.
         /// </summary>
         [TestMethod]
         public void FailToGetALog()

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -129,7 +129,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        /// Verify that when the limit is lower than the number of logs for the given channel, all logs are returned.
+        /// Verify that pending logs are not returned but other logs are.
         /// </summary>
         [TestMethod]
         public void GetLogsExcludesPendingLogsWithoutAffectingLimit()


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Getting logs from storage would filter out pending logs, which is correct, but the pending logs would still count toward the log limit in the request. Fix this by filtering out the pending logs at the query level.

I was able to repro the issue with the puppet app before the change, but not after.