### PR TITLE
Fix UWP device information helper test

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.UWP/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.UWP/Utils/DeviceInformationHelper.cs
@@ -54,6 +54,14 @@ namespace Microsoft.AppCenter.Utils
             InformationInvalidated?.Invoke(null, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// This is for testing purposes only. Do not call (unless you are a test).
+        /// </summary>
+        internal static void ResetScreenSizeProvider()
+        {
+            ScreenSizeProvider = null;
+        }
+
         protected override string GetSdkName()
         {
             return "appcenter.uwp";

--- a/Tests/Microsoft.AppCenter.Test.UWP/Utils/DeviceInformationHelperTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.UWP/Utils/DeviceInformationHelperTest.cs
@@ -45,14 +45,14 @@ namespace Microsoft.AppCenter.Test.UWP.Utils
             var informationInvalidated = false;
             var screenSizeProviderMock = new Mock<IScreenSizeProvider>();
             var screenSizeProviderFactoryMock = new Mock<IScreenSizeProviderFactory>();
-
-            screenSizeProviderMock.Setup(provider => provider.ScreenSize).Returns(testScreenSize);
             screenSizeProviderFactoryMock.Setup(factory => factory.CreateScreenSizeProvider()).Returns(screenSizeProviderMock.Object);
+            screenSizeProviderMock.Setup(provider => provider.ScreenSize).Returns(testScreenSize);
             DeviceInformationHelper.SetScreenSizeProviderFactory(screenSizeProviderFactoryMock.Object);
+            DeviceInformationHelper.ResetScreenSizeProvider();
 
             // Screen size is returned from screen size provider
             var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
-            Assert.AreEqual(device.ScreenSize, testScreenSize);
+            Assert.AreEqual(testScreenSize, device.ScreenSize);
 
             // InformationInvalidated is invoked when ScreenSizeChanged event is raised
             DeviceInformationHelper.InformationInvalidated += (sender, args) => { informationInvalidated = true; };


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The test was failing when run with others because they would initialize the static property for screen size without the mock. This PR allows the test to reset the state.