### PR TITLE
After restarting application, the Others tab shows that Auth is automatically signed out

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -15,6 +15,8 @@ namespace Contoso.Forms.Demo
 {
     using XamarinDevice = Xamarin.Forms.Device;
 
+    private const string ACCOUNT_ID = "accountId";
+
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class OthersContentPage
     { 
@@ -45,7 +47,7 @@ namespace Contoso.Forms.Demo
             DistributeEnabledSwitchCell.IsEnabled = acEnabled;
             PushEnabledSwitchCell.On = await Push.IsEnabledAsync();
             PushEnabledSwitchCell.IsEnabled = acEnabled;
-            if (Application.Current.Properties.ContainsKey("accountId") && Application.Current.Properties["accountId"] is string id)
+            if (Application.Current.Properties.ContainsKey(ACCOUNT_ID) && Application.Current.Properties[ACCOUNT_ID] is string id)
             {
                 SignInInformationButton.Text = "User authenticated";
             }
@@ -69,7 +71,7 @@ namespace Contoso.Forms.Demo
                 userInfo = await Auth.SignInAsync();
                 if (userInfo.AccountId != null)
                 {
-                    Application.Current.Properties["accountId"] = userInfo.AccountId;
+                    Application.Current.Properties[ACCOUNT_ID] = userInfo.AccountId;
                     SignInInformationButton.Text = "User authenticated";
                 }
                 AppCenterLog.Info(App.LogTag, "Auth.SignInAsync succeeded accountId=" + userInfo.AccountId);
@@ -127,7 +129,7 @@ namespace Contoso.Forms.Demo
         {
             if (userInfo != null)
             {
-                Application.Current.Properties["accountId"] = null;
+                Application.Current.Properties[ACCOUNT_ID] = null;
                 string accessToken = userInfo.AccessToken?.Length > 0 ? "Set" : "Unset";
                 string idToken = userInfo.IdToken?.Length > 0 ? "Set" : "Unset";
                 await Navigation.PushModalAsync(new SignInInformationContentPage(userInfo.AccountId, accessToken, idToken));

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -47,11 +47,18 @@ namespace Contoso.Forms.Demo
             DistributeEnabledSwitchCell.IsEnabled = acEnabled;
             PushEnabledSwitchCell.On = await Push.IsEnabledAsync();
             PushEnabledSwitchCell.IsEnabled = acEnabled;
-            if (Application.Current.Properties.ContainsKey(AccountId) && Application.Current.Properties[AccountId] is string id)
+            if (!Application.Current.Properties.ContainsKey(AccountId))
+            {
+                SignInInformationButton.Text = "Authentication status unknown";
+            }
+            else if (Application.Current.Properties[AccountId] is string)
             {
                 SignInInformationButton.Text = "User authenticated";
             }
-            else SignInInformationButton.Text = "User not authenticated";
+            else
+            {
+                SignInInformationButton.Text = "User not authenticated";
+            }
         }
 
         async void UpdateDistributeEnabled(object sender, ToggledEventArgs e)

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -55,11 +55,11 @@ namespace Contoso.Forms.Demo
             }
             else if (Application.Current.Properties[AccountId] is string)
             {
-                SignInInformationButton.Text = "User authenticated";
+                SignInInformationButton.Text = "User is authenticated";
             }
             else
             {
-                SignInInformationButton.Text = "User not authenticated";
+                SignInInformationButton.Text = "User is not authenticated";
             }
         }
 

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -45,7 +45,7 @@ namespace Contoso.Forms.Demo
             DistributeEnabledSwitchCell.IsEnabled = acEnabled;
             PushEnabledSwitchCell.On = await Push.IsEnabledAsync();
             PushEnabledSwitchCell.IsEnabled = acEnabled;
-            if (userInfo?.AccountId != null)
+            if (Application.Current.Properties.ContainsKey("accountId") && Application.Current.Properties["accountId"] is string id)
             {
                 SignInInformationButton.Text = "User authenticated";
             }
@@ -69,6 +69,7 @@ namespace Contoso.Forms.Demo
                 userInfo = await Auth.SignInAsync();
                 if (userInfo.AccountId != null)
                 {
+                    Application.Current.Properties["accountId"] = userInfo.AccountId;
                     SignInInformationButton.Text = "User authenticated";
                 }
                 AppCenterLog.Info(App.LogTag, "Auth.SignInAsync succeeded accountId=" + userInfo.AccountId);
@@ -126,6 +127,7 @@ namespace Contoso.Forms.Demo
         {
             if (userInfo != null)
             {
+                Application.Current.Properties["accountId"] = null;
                 string accessToken = userInfo.AccessToken?.Length > 0 ? "Set" : "Unset";
                 string idToken = userInfo.IdToken?.Length > 0 ? "Set" : "Unset";
                 await Navigation.PushModalAsync(new SignInInformationContentPage(userInfo.AccountId, accessToken, idToken));

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -15,11 +15,10 @@ namespace Contoso.Forms.Demo
 {
     using XamarinDevice = Xamarin.Forms.Device;
 
-    private const string AccountId = "accountId";
-
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class OthersContentPage
-    { 
+    {
+
         static OthersContentPage()
         {
             Data.RemoteOperationCompleted += (sender, eventArgs) =>
@@ -29,7 +28,8 @@ namespace Contoso.Forms.Demo
         }
 
         private UserInformation userInfo;
-	
+        private const string AccountId = "accountId";
+
         public OthersContentPage()
         {
             InitializeComponent();
@@ -47,7 +47,7 @@ namespace Contoso.Forms.Demo
             DistributeEnabledSwitchCell.IsEnabled = acEnabled;
             PushEnabledSwitchCell.On = await Push.IsEnabledAsync();
             PushEnabledSwitchCell.IsEnabled = acEnabled;
-            if (Application.Current.Properties.ContainsKey(AccountId) && Application.Current.Properties[ACCOUNT_ID] is string id)
+            if (Application.Current.Properties.ContainsKey(AccountId) && Application.Current.Properties[AccountId] is string id)
             {
                 SignInInformationButton.Text = "User authenticated";
             }
@@ -122,6 +122,7 @@ namespace Contoso.Forms.Demo
         {
             Auth.SignOut();
             userInfo = null;
+            Application.Current.Properties[AccountId] = null;
             SignInInformationButton.Text = "User not authenticated";
         }
 
@@ -129,7 +130,6 @@ namespace Contoso.Forms.Demo
         {
             if (userInfo != null)
             {
-                Application.Current.Properties[AccountId] = null;
                 string accessToken = userInfo.AccessToken?.Length > 0 ? "Set" : "Unset";
                 string idToken = userInfo.IdToken?.Length > 0 ? "Set" : "Unset";
                 await Navigation.PushModalAsync(new SignInInformationContentPage(userInfo.AccountId, accessToken, idToken));

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -18,7 +18,6 @@ namespace Contoso.Forms.Demo
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class OthersContentPage
     {
-
         static OthersContentPage()
         {
             Data.RemoteOperationCompleted += (sender, eventArgs) =>
@@ -28,6 +27,7 @@ namespace Contoso.Forms.Demo
         }
 
         private UserInformation userInfo;
+
         private const string AccountId = "accountId";
 
         public OthersContentPage()

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/OthersContentPage.xaml.cs
@@ -15,7 +15,7 @@ namespace Contoso.Forms.Demo
 {
     using XamarinDevice = Xamarin.Forms.Device;
 
-    private const string ACCOUNT_ID = "accountId";
+    private const string AccountId = "accountId";
 
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class OthersContentPage
@@ -47,7 +47,7 @@ namespace Contoso.Forms.Demo
             DistributeEnabledSwitchCell.IsEnabled = acEnabled;
             PushEnabledSwitchCell.On = await Push.IsEnabledAsync();
             PushEnabledSwitchCell.IsEnabled = acEnabled;
-            if (Application.Current.Properties.ContainsKey(ACCOUNT_ID) && Application.Current.Properties[ACCOUNT_ID] is string id)
+            if (Application.Current.Properties.ContainsKey(AccountId) && Application.Current.Properties[ACCOUNT_ID] is string id)
             {
                 SignInInformationButton.Text = "User authenticated";
             }
@@ -71,7 +71,7 @@ namespace Contoso.Forms.Demo
                 userInfo = await Auth.SignInAsync();
                 if (userInfo.AccountId != null)
                 {
-                    Application.Current.Properties[ACCOUNT_ID] = userInfo.AccountId;
+                    Application.Current.Properties[AccountId] = userInfo.AccountId;
                     SignInInformationButton.Text = "User authenticated";
                 }
                 AppCenterLog.Info(App.LogTag, "Auth.SignInAsync succeeded accountId=" + userInfo.AccountId);
@@ -129,7 +129,7 @@ namespace Contoso.Forms.Demo
         {
             if (userInfo != null)
             {
-                Application.Current.Properties[ACCOUNT_ID] = null;
+                Application.Current.Properties[AccountId] = null;
                 string accessToken = userInfo.AccessToken?.Length > 0 ? "Set" : "Unset";
                 string idToken = userInfo.IdToken?.Length > 0 ? "Set" : "Unset";
                 await Navigation.PushModalAsync(new SignInInformationContentPage(userInfo.AccountId, accessToken, idToken));

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/OthersContentPage.xaml.cs
@@ -22,6 +22,8 @@ namespace Contoso.Forms.Puppet
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class OthersContentPage
     {
+        private const string AccountId = "accountId";
+
         static bool _rumStarted;
 
         static bool _eventFilterStarted;
@@ -57,11 +59,14 @@ namespace Contoso.Forms.Puppet
             RumEnabledSwitchCell.IsEnabled = acEnabled;
             EventFilterEnabledSwitchCell.On = _eventFilterStarted && await EventFilterHolder.Implementation?.IsEnabledAsync();
             EventFilterEnabledSwitchCell.IsEnabled = acEnabled && EventFilterHolder.Implementation != null;
-            if (userInfo?.AccountId != null)
+            if (Application.Current.Properties.ContainsKey(AccountId) && Application.Current.Properties[AccountId] is string id)
             {
                 SignInInformationButton.Text = "User authenticated";
             }
-            else SignInInformationButton.Text = "User not authenticated";
+            else
+            {
+                SignInInformationButton.Text = "User not authenticated";
+            }
         }
 
         async void UpdateDistributeEnabled(object sender, ToggledEventArgs e)
@@ -105,6 +110,7 @@ namespace Contoso.Forms.Puppet
                 userInfo = await Auth.SignInAsync();
                 if (userInfo.AccountId != null)
                 {
+                    Application.Current.Properties[AccountId] = userInfo.AccountId;
                     SignInInformationButton.Text = "User authenticated";
                 }
                 AppCenterLog.Info(App.LogTag, "Auth.SignInAsync succeeded accountId=" + userInfo.AccountId);
@@ -194,6 +200,7 @@ namespace Contoso.Forms.Puppet
             Auth.SignOut();
             userInfo = null;
             SignInInformationButton.Text = "User not authenticated";
+            Application.Current.Properties[AccountId] = null;
         }
 
         async void SignInInformation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/OthersContentPage.xaml.cs
@@ -59,7 +59,11 @@ namespace Contoso.Forms.Puppet
             RumEnabledSwitchCell.IsEnabled = acEnabled;
             EventFilterEnabledSwitchCell.On = _eventFilterStarted && await EventFilterHolder.Implementation?.IsEnabledAsync();
             EventFilterEnabledSwitchCell.IsEnabled = acEnabled && EventFilterHolder.Implementation != null;
-            if (Application.Current.Properties.ContainsKey(AccountId) && Application.Current.Properties[AccountId] is string id)
+            if (!Application.Current.Properties.ContainsKey(AccountId))
+            {
+                SignInInformationButton.Text = "Authentication status unknown";
+            }
+            else if (Application.Current.Properties[AccountId] is string)
             {
                 SignInInformationButton.Text = "User authenticated";
             }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/OthersContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/OthersContentPage.xaml.cs
@@ -65,11 +65,11 @@ namespace Contoso.Forms.Puppet
             }
             else if (Application.Current.Properties[AccountId] is string)
             {
-                SignInInformationButton.Text = "User authenticated";
+                SignInInformationButton.Text = "User is authenticated";
             }
             else
             {
-                SignInInformationButton.Text = "User not authenticated";
+                SignInInformationButton.Text = "User is not authenticated";
             }
         }
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

**Repro Steps**

1. Open the ACFDemo test app and go to Others tab
2. Click "Test MBaaS" button and Sign in your social account
3. Check if the Auth has successfully signed in and it shows "User  authenticated"
4. Restart the test app and go to Others tab
5. Check if the Auth is automatically signed out and it shows "User not authenticated"

**Expected Behaviour**
After restarting application, the Auth should still signed in on the Others tab
 
**Actual Behaviour**
After restarting application, the Others tab shows that Auth is automatically signed out

## Related PRs or issues

[AB#63530](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63530)
