### PR TITLE
Fix/crash ios update

### DIFF
--- a/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.puppet" android:versionCode="57" android:versionName="2.2.0-SNAPSHOT" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.puppet" android:versionCode="58" android:versionName="2.1.1-SNAPSHOT" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
 	<application android:label="SXPuppet" android:icon="@drawable/Icon" android:theme="@style/PuppetTheme">
 		<receiver android:name="com.google.firebase.iid.FirebaseInstanceIdInternalReceiver" android:exported="false" />

--- a/Apps/Contoso.Android.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Android.Puppet/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="58" android:versionName="2.2.0-SNAPSHOT" package="com.microsoft.appcenter.xamarin.forms.puppet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="59" android:versionName="2.1.1-SNAPSHOT" package="com.microsoft.appcenter.xamarin.forms.puppet">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
 	<application android:label="ACFPuppet">
 		<activity android:name="com.microsoft.identity.client.BrowserTabActivity">

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AssemblyInfo.cs
@@ -22,8 +22,8 @@ using Android.App;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Package.appxmanifest
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="10805zumoTestUser.AppCenter-Contoso.Forms.Puppet.U" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="2.2.0.0" />
+  <Identity Name="10805zumoTestUser.AppCenter-Contoso.Forms.Puppet.U" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="2.1.1.0" />
   <mp:PhoneIdentity PhoneProductId="55497ed8-b2ac-4485-ba79-e2b65bb720ed" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>AppCenter-Contoso.Forms.Puppet.UWP</DisplayName>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.UWP/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: ComVisible(false)]

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Info.plist
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/Info.plist
@@ -5,9 +5,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.microsoft.appcenter.xamarin.forms.puppet</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0</string>
+	<string>2.1.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Apps/Contoso.UWP.Puppet/Package.appxmanifest
+++ b/Apps/Contoso.UWP.Puppet/Package.appxmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="10805zumoTestUser.AppCenter-Contoso.UWP.Puppet" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="2.2.0.0" />
+  <Identity Name="10805zumoTestUser.AppCenter-Contoso.UWP.Puppet" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="2.1.1.0" />
   <mp:PhoneIdentity PhoneProductId="ce1e8604-09a9-4ffb-846b-8762beb84188" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>AppCenter-Contoso.UWP.Puppet</DisplayName>

--- a/Apps/Contoso.UWP.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.UWP.Puppet/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: ComVisible(false)]

--- a/Apps/Contoso.WPF.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.WPF.Puppet/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/Apps/Contoso.WinForms.Puppet/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.WinForms.Puppet/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/Apps/Contoso.iOS.Puppet/Info.plist
+++ b/Apps/Contoso.iOS.Puppet/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.microsoft.appcenter.xamarin.puppet</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0</string>
+	<string>2.1.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for .NET Change Log
 
+## Version 2.1.1
+
+### App Center Distribute
+
+#### iOS
+
+* **[Fix]** Fix a crash (regression from version 2.1.0) when checking for in-app updates.
+
 ## Version 2.1.0
 
 ### App Center

--- a/SDK/AppCenter/Microsoft.AppCenter.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Android.Bindings/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenter/Microsoft.AppCenter.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Android/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenter/Microsoft.AppCenter.Shared/WrapperSdk.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Shared/WrapperSdk.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AppCenter
         public const string Name = "appcenter.xamarin";
 
         /* We can't use reflection for assemblyInformationalVersion on iOS with "Link All" optimization. */
-        internal const string Version = "2.2.0-SNAPSHOT";
+        internal const string Version = "2.1.1-SNAPSHOT";
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.UWP/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 [assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("Microsoft.AppCenter.Test.UWP")]

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Properties/AssemblyInfo.cs
@@ -28,6 +28,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 [assembly: InternalsVisibleTo("Microsoft.AppCenter.Test.WindowsDesktop")]

--- a/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenter/Microsoft.AppCenter.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.iOS/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenter/Microsoft.AppCenter/Microsoft.AppCenter.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter/Microsoft.AppCenter.csproj
@@ -7,9 +7,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Core</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Core</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.xml</DocumentationFile>
   </PropertyGroup>

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Android.Bindings/Properties/AssemblyInfo.cs
@@ -21,8 +21,8 @@ using System.Runtime.InteropServices;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Android/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.UWP/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: ComVisible(false)]

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.WindowsDesktop/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.WindowsDesktop/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Microsoft.AppCenter.Analytics.csproj
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Microsoft.AppCenter.Analytics.csproj
@@ -6,9 +6,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Analytics</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Analytics</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Analytics.xml</DocumentationFile>
   </PropertyGroup>

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android.Bindings.Msal.Common/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android.Bindings.Msal.Common/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Android.App;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android.Bindings.Msal/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android.Bindings.Msal/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Android.App;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android.Bindings/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Android.App;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.Android/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Android.App;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth.iOS/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterAuth/Microsoft.AppCenter.Auth/Microsoft.AppCenter.Auth.csproj
+++ b/SDK/AppCenterAuth/Microsoft.AppCenter.Auth/Microsoft.AppCenter.Auth.csproj
@@ -7,9 +7,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Auth</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Auth</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Auth.xml</DocumentationFile>
   </PropertyGroup>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android.Bindings/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 [assembly: ComVisible(false)]

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.WindowsDesktop/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.WindowsDesktop/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes/Microsoft.AppCenter.Crashes.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes/Microsoft.AppCenter.Crashes.csproj
@@ -7,9 +7,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Crashes</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Crashes</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Crashes.xml</DocumentationFile>
   </PropertyGroup>

--- a/SDK/AppCenterData/Microsoft.AppCenter.Data.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterData/Microsoft.AppCenter.Data.Android.Bindings/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Android.App;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterData/Microsoft.AppCenter.Data.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterData/Microsoft.AppCenter.Data.Android/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using Android.App;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterData/Microsoft.AppCenter.Data.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterData/Microsoft.AppCenter.Data.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterData/Microsoft.AppCenter.Data.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterData/Microsoft.AppCenter.Data.iOS/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterData/Microsoft.AppCenter.Data/Microsoft.AppCenter.Data.csproj
+++ b/SDK/AppCenterData/Microsoft.AppCenter.Data/Microsoft.AppCenter.Data.csproj
@@ -6,9 +6,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Data</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Data</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Data.xml</DocumentationFile>
   </PropertyGroup>

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Android.Bindings/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Android/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/ApiDefinition.cs
@@ -79,8 +79,8 @@ namespace Microsoft.AppCenter.Distribute.iOS.Bindings
         [Export("releaseNotesUrl")]
         NSUrl ReleaseNotesUrl { get; }
 
-        // @property(nonatomic) BOOL mandatoryUpdate;
-        [Export("mandatoryUpdate")]
+        // @property(nonatomic, getter=isMandatoryUpdate) BOOL mandatoryUpdate;
+        [Export("isMandatoryUpdate")]
         bool MandatoryUpdate { get; }
     }
 }

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute/Microsoft.AppCenter.Distribute.csproj
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute/Microsoft.AppCenter.Distribute.csproj
@@ -7,9 +7,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Distribute</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Distribute</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Distribute.xml</DocumentationFile>
   </PropertyGroup>

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.Android.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.Android.Bindings/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.Android/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.UWP/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 [assembly: ReferenceAssembly]
 #endif
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("Microsoft.AppCenter.Test.UWP")]

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.iOS.Bindings/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.iOS.Bindings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using Foundation;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push.iOS/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push.iOS/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterPush/Microsoft.AppCenter.Push/Microsoft.AppCenter.Push.csproj
+++ b/SDK/AppCenterPush/Microsoft.AppCenter.Push/Microsoft.AppCenter.Push.csproj
@@ -7,9 +7,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Push</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Push</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Push.xml</DocumentationFile>
     <Description />

--- a/SDK/AppCenterRum/Microsoft.AppCenter.Rum.Android/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterRum/Microsoft.AppCenter.Rum.Android/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/SDK/AppCenterRum/Microsoft.AppCenter.Rum.UWP/Properties/AssemblyInfo.cs
+++ b/SDK/AppCenterRum/Microsoft.AppCenter.Rum.UWP/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: ComVisible(false)]

--- a/SDK/AppCenterRum/Microsoft.AppCenter.Rum/Microsoft.AppCenter.Rum.csproj
+++ b/SDK/AppCenterRum/Microsoft.AppCenter.Rum/Microsoft.AppCenter.Rum.csproj
@@ -7,9 +7,9 @@
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Product>Microsoft.AppCenter.Rum</Product>
     <Company>Microsoft Corporation</Company>
-    <Version>2.2.0-SNAPSHOT</Version>
+    <Version>2.1.1-SNAPSHOT</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <AssemblyTitle>Microsoft.AppCenter.Rum</AssemblyTitle>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.AppCenter.Rum.xml</DocumentationFile>
   </PropertyGroup>

--- a/Tests/Contoso.Forms.Test/Properties/AssemblyInfo.cs
+++ b/Tests/Contoso.Forms.Test/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Tests/Droid/Properties/AndroidManifest.xml
+++ b/Tests/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="56" android:versionName="2.2.0-SNAPSHOT" package="com.contoso.contoso_forms_test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="57" android:versionName="2.1.1-SNAPSHOT" package="com.contoso.contoso_forms_test">
 	<uses-sdk android:minSdkVersion="16" />
 	<application android:label="Contoso.Forms.Test"></application>
 </manifest>

--- a/Tests/Droid/Properties/AssemblyInfo.cs
+++ b/Tests/Droid/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Reflection;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Tests/Microsoft.AppCenter.Analytics.NET/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Analytics.NET/Properties/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 [assembly: InternalsVisibleTo("Microsoft.AppCenter.Analytics.Test.Windows")]

--- a/Tests/Microsoft.AppCenter.Analytics.Test.Windows/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Analytics.Test.Windows/Properties/AssemblyInfo.cs
@@ -19,5 +19,5 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/Tests/Microsoft.AppCenter.NET/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.NET/Properties/AssemblyInfo.cs
@@ -36,8 +36,8 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]
 
 [assembly: InternalsVisibleTo("Microsoft.AppCenter.Test.Windows")]
 [assembly: InternalsVisibleTo("Microsoft.AppCenter.Analytics.Test.Windows")]

--- a/Tests/Microsoft.AppCenter.Push.NET/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Push.NET/Properties/AssemblyInfo.cs
@@ -36,4 +36,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]

--- a/Tests/Microsoft.AppCenter.Push.Test.Windows/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Push.Test.Windows/Properties/AssemblyInfo.cs
@@ -36,4 +36,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]

--- a/Tests/Microsoft.AppCenter.Test.UWP/Package.appxmanifest
+++ b/Tests/Microsoft.AppCenter.Test.UWP/Package.appxmanifest
@@ -7,7 +7,7 @@
 
   <Identity Name="da6d3d34-876e-488c-9342-7a7e4daa110b"
             Publisher="CN=Alexander Chocron"
-            Version="2.2.0.0" />
+            Version="2.1.1.0" />
 
   <mp:PhoneIdentity PhoneProductId="da6d3d34-876e-488c-9342-7a7e4daa110b" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/Tests/Microsoft.AppCenter.Test.UWP/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Test.UWP/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 [assembly: ComVisible(false)]

--- a/Tests/Microsoft.AppCenter.Test.Windows/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Properties/AssemblyInfo.cs
@@ -19,5 +19,5 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.0-SNAPSHOT")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.1-SNAPSHOT")]

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Properties/AssemblyInfo.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop/Properties/AssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]

--- a/Tests/iOS/Info.plist
+++ b/Tests/iOS/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.contoso.contoso-forms-test</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0</string>
+	<string>2.1.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/scripts/configuration/ac-build-config.xml
+++ b/scripts/configuration/ac-build-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config>
     <sdkInfo>
-        <sdkVersion>2.2.0-SNAPSHOT</sdkVersion>
+        <sdkVersion>2.1.1-SNAPSHOT</sdkVersion>
         <iosVersion>2.1.0</iosVersion>
         <androidVersion>2.1.0</androidVersion>
     </sdkInfo>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix regression from SDK 2.1.0 where in-app updates are crashing on iOS.

Fix is https://github.com/microsoft/appcenter-sdk-dotnet/pull/996/commits/f3f85098e2121356b4fdf05e5842e7031bcb456b, the rest is version/changelog as we will release this fix.

## Related PRs or issues

[AB#63648](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63648)
