### PR TITLE
Prevent userId from being cleared on application close

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -35,10 +35,6 @@ namespace Contoso.Forms.Demo
             if (!AppCenter.Configured)
             {
                 AppCenter.LogLevel = LogLevel.Verbose;
-                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
-                {
-                    AppCenter.SetUserId(id);
-                }
                 Crashes.SendingErrorReport += SendingErrorReportHandler;
                 Crashes.SendingErrorReport += SendingErrorReportHandler;
                 Crashes.SentErrorReport += SentErrorReportHandler;
@@ -50,6 +46,10 @@ namespace Contoso.Forms.Demo
                 Push.PushNotificationReceived += OnPushNotificationReceived;
                 AppCenter.Start($"uwp={uwpKey};android={androidKey};ios={iosKey}",
                                    typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Push), typeof(Auth), typeof(Data));
+                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
+                {
+                    AppCenter.SetUserId(id);
+                }
                 AppCenter.GetInstallIdAsync().ContinueWith(installId =>
                 {
                     AppCenterLog.Info(LogTag, "AppCenter.InstallId=" + installId.Result);

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -35,6 +35,10 @@ namespace Contoso.Forms.Demo
             if (!AppCenter.Configured)
             {
                 AppCenter.LogLevel = LogLevel.Verbose;
+                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
+                {
+                    AppCenter.SetUserId(id);
+                }
                 Crashes.SendingErrorReport += SendingErrorReportHandler;
                 Crashes.SendingErrorReport += SendingErrorReportHandler;
                 Crashes.SentErrorReport += SentErrorReportHandler;

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -28,7 +28,7 @@ namespace Contoso.Forms.Demo
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
             if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
             {
-                UserIdEntryCell.Text = id;
+                UserId = id;
             }
         }
 

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -11,8 +11,6 @@ namespace Contoso.Forms.Demo
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class AppCenterContentPage : ContentPage
     {
-        public static string UserIdKey = "userId";
-
         public AppCenterContentPage()
         {
             InitializeComponent();
@@ -26,10 +24,6 @@ namespace Contoso.Forms.Demo
         {
             base.OnAppearing();
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
-            if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
-            {
-                UserId = id;
-            }
         }
 
         async void UpdateEnabled(object sender, ToggledEventArgs e)
@@ -42,8 +36,16 @@ namespace Contoso.Forms.Demo
     public class EntryCellTextChanged : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
-
+        private const string UserIdKey = "userId";
         private string _userId;
+
+        public EntryCellTextChanged()
+        {
+            if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
+            {
+                UserId = id;
+            }
+        }
 
         public string UserId
         {
@@ -65,7 +67,7 @@ namespace Contoso.Forms.Demo
                 PropertyChanged(this, new PropertyChangedEventArgs(inputText));
                 var text = string.IsNullOrEmpty(inputText) ? null : inputText;
                 AppCenter.SetUserId(text);
-                Application.Current.Properties[AppCenterContentPage.UserIdKey] = text;
+                Application.Current.Properties[UserIdKey] = text;
             }
         }
     }

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -36,7 +36,9 @@ namespace Contoso.Forms.Demo
     public class EntryCellTextChanged : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
+
         private const string UserIdKey = "userId";
+
         private string _userId;
 
         public EntryCellTextChanged()

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -37,7 +37,7 @@ namespace Contoso.Forms.Demo
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private const string UserIdKey = "userId";
+        internal static string UserIdKey = "userId";
 
         private string _userId;
 

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -11,6 +11,8 @@ namespace Contoso.Forms.Demo
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class AppCenterContentPage : ContentPage
     {
+        public static string UserIdKey = "userId";
+
         public AppCenterContentPage()
         {
             InitializeComponent();
@@ -24,6 +26,10 @@ namespace Contoso.Forms.Demo
         {
             base.OnAppearing();
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
+            if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
+            {
+                UserIdEntryCell.Text = id;
+            }
         }
 
         async void UpdateEnabled(object sender, ToggledEventArgs e)
@@ -59,6 +65,7 @@ namespace Contoso.Forms.Demo
                 PropertyChanged(this, new PropertyChangedEventArgs(inputText));
                 var text = string.IsNullOrEmpty(inputText) ? null : inputText;
                 AppCenter.SetUserId(text);
+                Application.Current.Properties[AppCenterContentPage.UserIdKey] = text;
             }
         }
     }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -54,15 +54,16 @@ namespace Contoso.Forms.Puppet
 
                 AppCenterLog.Assert(LogTag, "AppCenter.Configured=" + AppCenter.Configured);
                 AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
-                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
-                {
-                    AppCenter.SetUserId(id);
-                }
+               
                 Distribute.SetInstallUrl("https://install.portal-server-core-integration.dev.avalanch.es");
                 Distribute.SetApiUrl("https://api-gateway-core-integration.dev.avalanch.es/v0.1");
                 Auth.SetConfigUrl("https://config-integration.dev.avalanch.es");
                 Data.SetTokenExchangeUrl("https://token-exchange-mbaas-integration.dev.avalanch.es/v0.1");
                 AppCenter.Start($"uwp={UwpKey};android={AndroidKey};ios={IosKey}", typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Push), typeof(Auth), typeof(Data));
+                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
+                {
+                    AppCenter.SetUserId(id);
+                }
                 AppCenter.IsEnabledAsync().ContinueWith(enabled =>
                 {
                     AppCenterLog.Info(LogTag, "AppCenter.Enabled=" + enabled.Result);

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -54,6 +54,10 @@ namespace Contoso.Forms.Puppet
 
                 AppCenterLog.Assert(LogTag, "AppCenter.Configured=" + AppCenter.Configured);
                 AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
+                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
+                {
+                    AppCenter.SetUserId(id);
+                }
                 Distribute.SetInstallUrl("https://install.portal-server-core-integration.dev.avalanch.es");
                 Distribute.SetApiUrl("https://api-gateway-core-integration.dev.avalanch.es/v0.1");
                 Auth.SetConfigUrl("https://config-integration.dev.avalanch.es");

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml
@@ -3,6 +3,9 @@
              xmlns:local="clr-namespace:Contoso.Forms.Puppet"
              xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Contoso.Forms.Puppet.AppCenterContentPage">
+    <ContentPage.BindingContext>
+        <local:EntryCellTextChanged/>
+    </ContentPage.BindingContext>
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
             <SwitchCell Text="App Center Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled"/>
@@ -27,7 +30,7 @@
             </ViewCell>
         </TableSection>
         <TableSection Title="Logging">
-            <EntryCell Label="User Id" x:Name="UserIdEntryCell" HorizontalTextAlignment="End" Completed="UserIdCompleted"/>
+            <EntryCell Label="User Id" x:Name="UserIdEntryCell" Text="{Binding UserId, Mode=TwoWay}" HorizontalTextAlignment="End"/>
         </TableSection>
     </TableView>
 </ContentPage>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -11,9 +11,10 @@ namespace Contoso.Forms.Puppet
     [Android.Runtime.Preserve(AllMembers = true)]
     public partial class AppCenterContentPage : ContentPage
     {
+        private const string UserIdKey = "userId";
+        
         // E.g., calling LogFunctions["Verbose"](tag, msg) will be
         // equivalent to calling Verbose(tag, msg)
-        private const string UserIdKey = "userId";
         Dictionary<LogLevel, Action<string, string>> LogFunctions;
         Dictionary<LogLevel, string> LogLevelNames;
         LogLevel LogWriteLevel;

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -100,7 +100,7 @@ namespace Contoso.Forms.Puppet
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private const string UserIdKey = "userId";
+        internal static string UserIdKey = "userId";
 
         private string _userId;
 

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -13,6 +13,7 @@ namespace Contoso.Forms.Puppet
     {
         // E.g., calling LogFunctions["Verbose"](tag, msg) will be
         // equivalent to calling Verbose(tag, msg)
+        private const string UserIdKey = "userId";
         Dictionary<LogLevel, Action<string, string>> LogFunctions;
         Dictionary<LogLevel, string> LogLevelNames;
         LogLevel LogWriteLevel;
@@ -50,6 +51,10 @@ namespace Contoso.Forms.Puppet
             base.OnAppearing();
             LogLevelLabel.Text = LogLevelNames[AppCenter.LogLevel];
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
+            if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
+            {
+                UserIdEntryCell.Text = id;
+            }
         }
 
         void LogLevelCellTapped(object sender, EventArgs e)
@@ -94,6 +99,7 @@ namespace Contoso.Forms.Puppet
         {
             var text = string.IsNullOrEmpty(UserIdEntryCell.Text) ? null : UserIdEntryCell.Text;
             AppCenter.SetUserId(text);
+            Application.Current.Properties[UserIdKey] = text;
         }
     }
 }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

**Repro Steps**

1. Come to demo app on iOS
2. Type in a user id on the main screen
3. Send a push notification to the user id
4. Quit the app and restart it again and see the user id

**Expected Behaviour**
The user id can't be cleared once quit the demo app on Xamarin demo app.

**Actual Behaviour**
The user id can be cleared once quit the demo app on Xamarin demo app.

## Related PRs or issues

[AB#63529](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63529)

