### PR TITLE
Fix/Error properties' name can't be empty

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -11,6 +11,7 @@ using Contoso.Forms.Demo.Views;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Crashes;
 using Xamarin.Forms;
+using System.Linq;
 
 namespace Contoso.Forms.Demo
 {
@@ -101,6 +102,10 @@ namespace Contoso.Forms.Demo
             var addPage = new AddPropertyContentPage();
             addPage.PropertyAdded += (Property property) =>
             {
+                if (property.Name == null || Properties.Any(i => i.Name == property.Name))
+                {
+                    return;
+                }
                 Properties.Add(property);
                 RefreshPropCount();
             };


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Fix to Error properties' name can't be empty or duplicate.

## Related PRs or issues

[#63736](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/63736/?triage=true)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
