### PR TITLE
Feature/windows send error attachments

### DIFF
--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -213,11 +213,14 @@ namespace Microsoft.AppCenter.Crashes
                 tasks.Add(Channel.EnqueueAsync(log));
                 _unprocessedManagedErrorLogs.Remove(key);
                 ErrorLogHelper.RemoveStoredErrorLogFile(key);
-                var errorReport = new ErrorReport(log, null);
+                if (GetErrorAttachments != null)
+                {
+                    var errorReport = new ErrorReport(log, null);
 
-                // This must never called while a lock is held.
-                var attachments = GetErrorAttachments?.Invoke(errorReport);
-                tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
+                    // This must never called while a lock is held.
+                    var attachments = GetErrorAttachments?.Invoke(errorReport);
+                    tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
+                }
             }
             return Task.WhenAll(tasks);
         }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -214,23 +214,17 @@ namespace Microsoft.AppCenter.Crashes
                 tasks.Add(Channel.EnqueueAsync(log));
                 _unprocessedManagedErrorLogs.Remove(key);
                 ErrorLogHelper.RemoveStoredErrorLogFile(key);
-                
-                // Save callback into a local variable to avoid a race condition.
-                var errorAttachmentsCallback = GetErrorAttachments;
-                if (errorAttachmentsCallback != null)
-                {
-                    var errorReport = new ErrorReport(log, null);
+                var errorReport = new ErrorReport(log, null);
 
-                    // This must never called while a lock is held.
-                    var attachments = errorAttachmentsCallback.Invoke(errorReport);
-                    if (attachments == null)
-                    {
-                        AppCenterLog.Debug(LogTag, $"Crashes.GetErrorAttachments returned null; no additional information will be attached to log: {log.Id}.");
-                    }
-                    else
-                    {
-                        tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
-                    }
+                // This must never called while a lock is held.
+                var attachments = GetErrorAttachments?.Invoke(errorReport);
+                if (attachments == null)
+                {
+                    AppCenterLog.Debug(LogTag, $"Crashes.GetErrorAttachments returned null; no additional information will be attached to log: {log.Id}.");
+                }
+                else
+                {
+                    tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
                 }
             }
             return Task.WhenAll(tasks);

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AppCenter.Crashes
                     }
                 }
                 await SendCrashReportsOrAwaitUserConfirmationAsync();
-            }).ContinueWith((_) => ProcessPendingErrorsTask = null);
+            });
         }
 
         private Task SendCrashReportsOrAwaitUserConfirmationAsync()
@@ -214,6 +214,8 @@ namespace Microsoft.AppCenter.Crashes
                 _unprocessedManagedErrorLogs.Remove(key);
                 ErrorLogHelper.RemoveStoredErrorLogFile(key);
                 var errorReport = new ErrorReport(log, null);
+
+                // This must never called while a lock is held.
                 var attachments = GetErrorAttachments?.Invoke(errorReport);
                 tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
             }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AppCenter.Crashes
         static Crashes()
         {
             LogSerializer.AddLogType(ManagedErrorLog.JsonIdentifier, typeof(ManagedErrorLog));
+            LogSerializer.AddLogType(ErrorAttachmentLog.JsonIdentifier, typeof(ErrorAttachmentLog));
         }
 
         public static Crashes Instance

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -214,12 +214,15 @@ namespace Microsoft.AppCenter.Crashes
                 tasks.Add(Channel.EnqueueAsync(log));
                 _unprocessedManagedErrorLogs.Remove(key);
                 ErrorLogHelper.RemoveStoredErrorLogFile(key);
-                if (GetErrorAttachments != null)
+                
+                // Save callback into a local variable to avoid a race condition.
+                var errorAttachmentsCallback = GetErrorAttachments;
+                if (errorAttachmentsCallback != null)
                 {
                     var errorReport = new ErrorReport(log, null);
 
                     // This must never called while a lock is held.
-                    var attachments = GetErrorAttachments?.Invoke(errorReport);
+                    var attachments = errorAttachmentsCallback.Invoke(errorReport);
                     tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
                 }
             }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -223,7 +223,14 @@ namespace Microsoft.AppCenter.Crashes
 
                     // This must never called while a lock is held.
                     var attachments = errorAttachmentsCallback.Invoke(errorReport);
-                    tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
+                    if (attachments == null)
+                    {
+                        AppCenterLog.Debug(LogTag, $"Crashes.GetErrorAttachments returned null; no additional information will be attached to log: {log.Id}.");
+                    }
+                    else
+                    {
+                        tasks.Add(SendErrorAttachmentsAsync(log.Id, attachments));
+                    }
                 }
             }
             return Task.WhenAll(tasks);
@@ -231,11 +238,6 @@ namespace Microsoft.AppCenter.Crashes
 
         private Task SendErrorAttachmentsAsync(Guid errorId, IEnumerable<ErrorAttachmentLog> attachments)
         {
-            if (attachments == null)
-            {
-                AppCenterLog.Debug(LogTag, $"Crashes.GetErrorAttachments returned null; no additional information will be attached to log: {errorId}.");
-                return Task.FromResult(0);
-            }
             var totalErrorAttachments = 0;
             var tasks = new List<Task>();
             foreach (var attachment in attachments)

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/ErrorAttachmentLog.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/ErrorAttachmentLog.cs
@@ -10,9 +10,11 @@ namespace Microsoft.AppCenter.Crashes
     /// <summary>
     /// Error attachment log.
     /// </summary>
-    [JsonObject("errorAttachment")]
+    [JsonObject(JsonIdentifier)]
     public partial class ErrorAttachmentLog : Log
     {
+        internal const string JsonIdentifier = "errorAttachment";
+
         private const string ContentTypePlainText = "text/plain";
 
         static ErrorAttachmentLog PlatformAttachmentWithText(string text, string fileName)

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/ErrorAttachmentLog.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/ErrorAttachmentLog.cs
@@ -17,12 +17,20 @@ namespace Microsoft.AppCenter.Crashes
 
         static ErrorAttachmentLog PlatformAttachmentWithText(string text, string fileName)
         {
+            if (text == null)
+            {
+                return null;
+            }
             var data = Encoding.UTF8.GetBytes(text);
             return PlatformAttachmentWithBinary(data, fileName, ContentTypePlainText);
         }
 
         static ErrorAttachmentLog PlatformAttachmentWithBinary(byte[] data, string fileName, string contentType)
         {
+            if (data == null)
+            {
+                return null;
+            }
             return new ErrorAttachmentLog()
             {
                 Data = data,

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesErrorAttachmentTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesErrorAttachmentTest.cs
@@ -13,7 +13,6 @@ using Moq;
 
 namespace Microsoft.AppCenter.Crashes.Test.Windows
 {
-
     /// <summary>
     /// This class tests the error attachments functionality of the Crashes class.
     /// </summary>

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesErrorAttachmentTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesErrorAttachmentTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Microsoft.AppCenter.Channel;
 using Microsoft.AppCenter.Crashes.Ingestion.Models;
 using Microsoft.AppCenter.Crashes.Utils;
-using Microsoft.AppCenter.Ingestion.Models;
 using Microsoft.AppCenter.Utils;
 using Microsoft.AppCenter.Utils.Files;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesErrorAttachmentTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesErrorAttachmentTest.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AppCenter.Channel;
+using Microsoft.AppCenter.Crashes.Ingestion.Models;
+using Microsoft.AppCenter.Crashes.Utils;
+using Microsoft.AppCenter.Ingestion.Models;
+using Microsoft.AppCenter.Utils;
+using Microsoft.AppCenter.Utils.Files;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.AppCenter.Crashes.Test.Windows
+{
+
+    /// <summary>
+    /// This class tests the error attachments functionality of the Crashes class.
+    /// </summary>
+    [TestClass]
+    public class CrashesErrorAttachmentTest
+    {
+        private Mock<IChannelGroup> _mockChannelGroup;
+        private Mock<IChannelUnit> _mockChannel;
+        private Mock<IApplicationLifecycleHelper> _mockApplicationLifecycleHelper;
+
+        [TestInitialize]
+        public void InitializeCrashTest()
+        {
+            Crashes.Instance = new Crashes();
+            _mockChannelGroup = new Mock<IChannelGroup>();
+            _mockChannel = new Mock<IChannelUnit>();
+            _mockApplicationLifecycleHelper = new Mock<IApplicationLifecycleHelper>();
+            _mockChannelGroup.Setup(group => group.AddChannel(It.IsAny<string>(), It.IsAny<int>(),
+                    It.IsAny<TimeSpan>(), It.IsAny<int>()))
+                .Returns(_mockChannel.Object);
+            ApplicationLifecycleHelper.Instance = _mockApplicationLifecycleHelper.Object;
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // If a mock was set, reset it to null before moving on.
+            ErrorLogHelper.Instance = null;
+            ApplicationLifecycleHelper.Instance = null;
+            Crashes.Instance = null;
+        }
+
+        [TestMethod]
+        public void ProcessPendingCrashesSendsErrorAttachment()
+        {
+            var mockFile1 = Mock.Of<File>();
+            var mockFile2 = Mock.Of<File>();
+            var mockErrorLogHelper = Mock.Of<ErrorLogHelper>();
+            ErrorLogHelper.Instance = mockErrorLogHelper;
+            var expectedManagedErrorLog1 = new ManagedErrorLog {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device()
+            };
+            var expectedManagedErrorLog2 = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device()
+            };
+
+            // Mock error attachment log so that Validate method does not throw.
+            var mockErrorAttachment = Mock.Of<ErrorAttachmentLog>();
+
+            // Stub get/read/delete error files.
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceGetErrorLogFiles()).Returns(new List<File> { mockFile1, mockFile2 });
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceReadErrorLogFile(mockFile1)).Returns(expectedManagedErrorLog1);
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceReadErrorLogFile(mockFile2)).Returns(expectedManagedErrorLog2);
+
+            // Implement attachments callback.
+            Crashes.GetErrorAttachments = errorReport =>
+            {
+                if (errorReport.Id == expectedManagedErrorLog1.Id.ToString())
+                {
+                    return new List<ErrorAttachmentLog> { mockErrorAttachment };
+                }
+                return null;
+            };
+
+            Crashes.SetEnabledAsync(true).Wait();
+            Crashes.Instance.OnChannelGroupReady(_mockChannelGroup.Object, string.Empty);
+            Crashes.Instance.ProcessPendingErrorsTask.Wait();
+
+            // Verify attachment log has been queued to the channel. (And only one attachment log).
+            _mockChannel.Verify(channel => channel.EnqueueAsync(mockErrorAttachment), Times.Once());
+            _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<ErrorAttachmentLog>()), Times.Once());
+
+            // Verify that the attachment has been modified with the right fields.
+            Mock.Get(mockErrorAttachment).VerifySet(attachment => attachment.ErrorId = expectedManagedErrorLog1.Id);
+            Mock.Get(mockErrorAttachment).VerifySet(attachment => attachment.Id = It.IsAny<Guid>());
+        }
+
+        [TestMethod]
+        public void ProcessPendingCrashesIgnoresNullErrorAttachment()
+        {
+            var mockFile1 = Mock.Of<File>();
+            var mockFile2 = Mock.Of<File>();
+            var mockErrorLogHelper = Mock.Of<ErrorLogHelper>();
+            ErrorLogHelper.Instance = mockErrorLogHelper;
+            var expectedManagedErrorLog1 = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device()
+            };
+
+            // Stub get/read/delete error files.
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceGetErrorLogFiles()).Returns(new List<File> { mockFile1 });
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceReadErrorLogFile(mockFile1)).Returns(expectedManagedErrorLog1);
+
+            // Implement attachments callback.
+            Crashes.GetErrorAttachments = errorReport =>
+            {
+                if (errorReport.Id == expectedManagedErrorLog1.Id.ToString())
+                {
+                    return new List<ErrorAttachmentLog> { null };
+                }
+                return null;
+            };
+
+            Crashes.SetEnabledAsync(true).Wait();
+            Crashes.Instance.OnChannelGroupReady(_mockChannelGroup.Object, string.Empty);
+            Crashes.Instance.ProcessPendingErrorsTask.Wait();
+
+            // Verify nothing has been enqueued.
+            _mockChannel.Verify(channel => channel.EnqueueAsync(It.IsAny<ErrorAttachmentLog>()), Times.Never());
+        }
+
+        [TestMethod]
+        public void ProcessPendingCrashesIgnoresInvalidErrorAttachmentWithoutCrashing()
+        {
+            var mockFile1 = Mock.Of<File>();
+            var mockFile2 = Mock.Of<File>();
+            var mockErrorLogHelper = Mock.Of<ErrorLogHelper>();
+            ErrorLogHelper.Instance = mockErrorLogHelper;
+            var expectedManagedErrorLog1 = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device()
+            };
+            var expectedManagedErrorLog2 = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device()
+            };
+
+            // Stub get/read/delete error files.
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceGetErrorLogFiles()).Returns(new List<File> { mockFile1, mockFile2 });
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceReadErrorLogFile(mockFile1)).Returns(expectedManagedErrorLog1);
+            Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceReadErrorLogFile(mockFile2)).Returns(expectedManagedErrorLog2);
+
+            // Create two valid and one invalid attachment.
+            var mockInvalidErrorAttachment1 = Mock.Of<ErrorAttachmentLog>();
+            Mock.Get(mockInvalidErrorAttachment1).Setup(attachment => attachment.Validate()).Throws(new ValidationException());
+            var mockValidErrorAttachment1 = Mock.Of<ErrorAttachmentLog>();
+            var mockValidErrorAttachment2 = Mock.Of<ErrorAttachmentLog>();
+
+            // Implement attachments callback.
+            Crashes.GetErrorAttachments = errorReport =>
+            {
+                if (errorReport.Id == expectedManagedErrorLog1.Id.ToString())
+                {
+                    return new List<ErrorAttachmentLog> { mockInvalidErrorAttachment1, mockValidErrorAttachment1 };
+                }
+                return new List<ErrorAttachmentLog> { mockValidErrorAttachment2 };
+            };
+
+            Crashes.SetEnabledAsync(true).Wait();
+            Crashes.Instance.OnChannelGroupReady(_mockChannelGroup.Object, string.Empty);
+            Crashes.Instance.ProcessPendingErrorsTask.Wait();
+
+            // Verify all valid attachment logs has been queued to the channel, but not invalid one.
+            _mockChannel.Verify(channel => channel.EnqueueAsync(mockInvalidErrorAttachment1), Times.Never());
+            _mockChannel.Verify(channel => channel.EnqueueAsync(mockValidErrorAttachment1), Times.Once());
+            _mockChannel.Verify(channel => channel.EnqueueAsync(mockValidErrorAttachment2), Times.Once());
+        }
+    }
+}

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/CrashesTest.cs
@@ -94,8 +94,22 @@ namespace Microsoft.AppCenter.Crashes.Test.Windows
             var mockErrorLogHelper = Mock.Of<ErrorLogHelper>();
             ErrorLogHelper.Instance = mockErrorLogHelper;
             var expectedprocessId = 123;
-            var expectedManagedErrorLog1 = new ManagedErrorLog { Id = Guid.NewGuid(), ProcessId = expectedprocessId };
-            var expectedManagedErrorLog2 = new ManagedErrorLog { Id = Guid.NewGuid(), ProcessId = expectedprocessId };
+            var expectedManagedErrorLog1 = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device(),
+                ProcessId = expectedprocessId
+            };
+            var expectedManagedErrorLog2 = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device(),
+                ProcessId = expectedprocessId
+            };
 
             // Stub get/read/delete error files.
             Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceGetErrorLogFiles()).Returns(new List<File> { mockFile1, mockFile2 });
@@ -143,7 +157,13 @@ namespace Microsoft.AppCenter.Crashes.Test.Windows
             var mockCorruptedFile = Mock.Of<File>();
             var mockErrorLogHelper = Mock.Of<ErrorLogHelper>();
             ErrorLogHelper.Instance = mockErrorLogHelper;
-            var expectedManagedErrorLog = new ManagedErrorLog { Id = Guid.NewGuid() };
+            var expectedManagedErrorLog = new ManagedErrorLog
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.Now,
+                AppLaunchTimestamp = DateTime.Now,
+                Device = new Microsoft.AppCenter.Ingestion.Models.Device(),
+            };
 
             // Stub get/read/delete error files.
             Mock.Get(ErrorLogHelper.Instance).Setup(instance => instance.InstanceGetErrorLogFiles()).Returns(new List<File> { mockFile, mockCorruptedFile });

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/ErrorAttachmentLogTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/ErrorAttachmentLogTest.cs
@@ -4,7 +4,7 @@
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.AppCenter.Crashes.Test
+namespace Microsoft.AppCenter.Crashes.Test.Windows
 {
     [TestClass]
     public class ErrorAttachmentLogTest
@@ -36,6 +36,31 @@ namespace Microsoft.AppCenter.Crashes.Test
             Assert.AreEqual("text/plain", attachment.ContentType);
             Assert.AreEqual(fileName, attachment.FileName);
             Assert.AreEqual(text, Encoding.UTF8.GetString(attachment.Data));
+        }
+
+        [TestMethod]
+        public void TestCreateNullBinaryAttachmentLog()
+        {
+            // Attempt to create an error attachment log with null data.
+            var contentType = "mime/type";
+            byte[] data = null;
+            var fileName = "binary attachment";
+            var attachment = ErrorAttachmentLog.AttachmentWithBinary(data, fileName, contentType);
+
+            // Verify the result is null.
+            Assert.IsNull(attachment);
+        }
+
+        [TestMethod]
+        public void TestCreateNullTextAttachmentLog()
+        {
+            // Attempt to create an error attachment log with null text.
+            string text = null;
+            var fileName = "binary attachment";
+            var attachment = ErrorAttachmentLog.AttachmentWithText(text, fileName);
+
+            // Verify the result is null.
+            Assert.IsNull(attachment);
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/Microsoft.AppCenter.Crashes.Test.Windows.csproj
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/Microsoft.AppCenter.Crashes.Test.Windows.csproj
@@ -65,6 +65,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CrashesErrorAttachmentTest.cs" />
     <Compile Include="CrashesTest.cs" />
     <Compile Include="ErrorAttachmentLogTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Send error attachments if available for a crash.

Note: The part where the `ErrorReport` is created will likely be changed in the future (when we have exception available and probably some caching mechanism), but to avoid conflicts and double work, I kept it as simple as possible for now. (Also there is no exception file saved at the moment so calling the constructor is the only option anyways.)

[AB#63630](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63630)