### PR TITLE
appStartTime should be in UTC

### DIFF
--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AppCenter.Crashes.Utils
                 ProcessName = _processInformation.ProcessName,
                 ParentProcessId = _processInformation.ParentProcessId,
                 ParentProcessName = _processInformation.ParentProcessName,
-                AppLaunchTimestamp = _processInformation.ProcessStartTime.Value.ToUniversalTime(),
+                AppLaunchTimestamp = _processInformation.ProcessStartTime?.ToUniversalTime(),
                 Architecture = _processInformation.ProcessArchitecture,
                 Fatal = true,
                 Exception = CreateModelException(exception)

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AppCenter.Crashes.Utils
                 ProcessName = _processInformation.ProcessName,
                 ParentProcessId = _processInformation.ParentProcessId,
                 ParentProcessName = _processInformation.ParentProcessName,
-                AppLaunchTimestamp = _processInformation.ProcessStartTime,
+                AppLaunchTimestamp = _processInformation.ProcessStartTime.Value.ToUniversalTime(),
                 Architecture = _processInformation.ProcessArchitecture,
                 Fatal = true,
                 Exception = CreateModelException(exception)

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/Utils/ErrorLogHelperTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/Utils/ErrorLogHelperTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AppCenter.Crashes.Test.Windows.Utils
             var processArchitecture = "processArchitecture";
             var processId = 1;
             var processName = "processName";
-            var processStartTime = DateTime.Now;
+            var processStartTime = DateTime.Now.ToUniversalTime();
             Mock.Get(ErrorLogHelper.Instance._processInformation).SetupGet(instance => instance.ParentProcessId).Returns(parentProcessId);
             Mock.Get(ErrorLogHelper.Instance._processInformation).SetupGet(instance => instance.ParentProcessName).Returns(parentProcessName);
             Mock.Get(ErrorLogHelper.Instance._processInformation).SetupGet(instance => instance.ProcessArchitecture).Returns(processArchitecture);

--- a/Tests/Microsoft.AppCenter.Test.UWP/Microsoft.AppCenter.Test.UWP.csproj
+++ b/Tests/Microsoft.AppCenter.Test.UWP/Microsoft.AppCenter.Test.UWP.csproj
@@ -99,6 +99,7 @@
     <Compile Include="TestAppCenterService.cs" />
     <Compile Include="Utils\NetworkStateTests.cs" />
     <Compile Include="Utils\DefaultScreenSizeProviderTest.cs" />
+    <Compile Include="UWPCrashesTest.cs" />
     <Compile Include="UWPPushTest.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>

--- a/Tests/Microsoft.AppCenter.Test.UWP/UWPCrashesTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.UWP/UWPCrashesTest.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AppCenter.Crashes.Ingestion.Models;
+using Microsoft.AppCenter.Crashes.Utils;
+using Microsoft.AppCenter.Ingestion.Models.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using Microsoft.AppCenter.Utils.Files;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AppCenter.Test.UWP
+{
+    [TestClass]
+    public class UWPCrashesTest
+    {
+        [TestMethod]
+        public void VerifyAppLaunchTimestampUTC()
+        {
+            ManagedErrorLog managedErrorLog = ErrorLogHelper.CreateErrorLog(new System.Exception("Test Exception"));
+            Assert.AreEqual(managedErrorLog.AppLaunchTimestamp.Value.Kind, DateTimeKind.Utc);
+        }
+    }
+}

--- a/Tests/Microsoft.AppCenter.Test.UWP/UWPCrashesTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.UWP/UWPCrashesTest.cs
@@ -1,14 +1,7 @@
 ﻿using Microsoft.AppCenter.Crashes.Ingestion.Models;
 using Microsoft.AppCenter.Crashes.Utils;
-using Microsoft.AppCenter.Ingestion.Models.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using System;
-using Microsoft.AppCenter.Utils.Files;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Test.UWP
 {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

UWP error logs were not reporting the appLaunchTimestamp in UTC.

## Related PRs or issues

[AB#63921](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63921)
