### PR TITLE
Add  crashes callbacks functionality to test apps

### DIFF
--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -14,7 +14,7 @@ namespace Contoso.WPF.Demo
     /// </summary>
     public partial class App
     {
-        private const string LogTag = "AppCenterSasquatch";
+        private const string LogTag = "AppCenterDemo";
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -22,7 +22,7 @@ namespace Contoso.WPF.Demo
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
             Crashes.ShouldProcessErrorReport = ShouldProcess;
 
-            // Event handlers
+            // Event handlers.
             Crashes.SendingErrorReport += SendingErrorReportHandler;
             Crashes.SentErrorReport += SentErrorReportHandler;
             Crashes.FailedToSendErrorReport += FailedToSendErrorReportHandler;
@@ -60,8 +60,6 @@ namespace Contoso.WPF.Demo
         {
             AppCenterLog.Info(LogTag, "Sending error report");
             var report = e.Report;
-
-            // Test some values
             if (report.Exception != null)
             {
                 AppCenterLog.Info(LogTag, report.Exception.ToString());
@@ -72,8 +70,6 @@ namespace Contoso.WPF.Demo
         {
             AppCenterLog.Info(LogTag, "Sent error report");
             var report = e.Report;
-
-            // Test some values
             if (report.Exception != null)
             {
                 AppCenterLog.Info(LogTag, report.Exception.ToString());
@@ -88,8 +84,6 @@ namespace Contoso.WPF.Demo
         {
             AppCenterLog.Info(LogTag, "Failed to send error report");
             var report = e.Report;
-
-            // Test some values
             if (report.Exception != null)
             {
                 AppCenterLog.Info(LogTag, report.Exception.ToString());

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Globalization;
+using System.Windows;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
-using System;
-using System.Windows;
 
 namespace Contoso.WPF.Demo
 {
@@ -14,8 +15,6 @@ namespace Contoso.WPF.Demo
     /// </summary>
     public partial class App
     {
-        private const string LogTag = "AppCenterDemo";
-
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
@@ -29,21 +28,21 @@ namespace Contoso.WPF.Demo
             AppCenter.Start("f4e2a83d-3052-4884-8176-8b2c50277d16", typeof(Analytics), typeof(Crashes));
             Crashes.HasCrashedInLastSessionAsync().ContinueWith(hasCrashed =>
             {
-                AppCenterLog.Info(LogTag, "Crashes.HasCrashedInLastSession=" + hasCrashed.Result);
+                Log("Crashes.HasCrashedInLastSession=" + hasCrashed.Result);
             });
             Crashes.GetLastSessionCrashReportAsync().ContinueWith(task =>
             {
-                AppCenterLog.Info(LogTag, "Crashes.LastSessionCrashReport.Exception=" + task.Result?.Exception);
+                Log("Crashes.LastSessionCrashReport.Exception=" + task.Result?.Exception);
             });
         }
 
-        bool ShouldProcess(ErrorReport report)
+        private static bool ShouldProcess(ErrorReport report)
         {
-            AppCenterLog.Info(LogTag, "Determining whether to process error report");
+            Log("Determining whether to process error report");
             return true;
         }
 
-        bool ConfirmationHandler()
+        private static bool ConfirmationHandler()
         {
             Current.Dispatcher.Invoke(() =>
             {
@@ -56,42 +55,48 @@ namespace Contoso.WPF.Demo
             return true;
         }
 
-        static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
+        private static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
         {
-            AppCenterLog.Info(LogTag, "Sending error report");
+            Log("Sending error report");
             var report = e.Report;
             if (report.Exception != null)
             {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
+                Log(report.Exception.ToString());
             }
         }
 
         static void SentErrorReportHandler(object sender, SentErrorReportEventArgs e)
         {
-            AppCenterLog.Info(LogTag, "Sent error report");
+            Log("Sent error report");
             var report = e.Report;
             if (report.Exception != null)
             {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
+                Log(report.Exception.ToString());
             }
             else
             {
-                AppCenterLog.Info(LogTag, "No system exception was found");
+                Log("No system exception was found");
             }
         }
 
-        static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
+        private static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
         {
-            AppCenterLog.Info(LogTag, "Failed to send error report");
+            Log("Failed to send error report");
             var report = e.Report;
             if (report.Exception != null)
             {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
+                Log(report.Exception.ToString());
             }
             if (e.Exception != null)
             {
-                AppCenterLog.Info(LogTag, "There is an exception associated with the failure");
+                Log("There is an exception associated with the failure");
             }
+        }
+
+        private static void Log(string message)
+        {
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
+            System.Diagnostics.Debug.WriteLine($"{timestamp} [AppCenterDemo] Info: {message}");
         }
     }
 }

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -45,14 +45,14 @@ namespace Contoso.WPF.Demo
 
         bool ConfirmationHandler()
         {
-            Current.Dispatcher.Invoke(new Action(() =>
+            Current.Dispatcher.Invoke(() =>
             {
                 var dialog = new UserConfirmationDialog();
-                if (dialog.ShowDialog() == true)
+                if (dialog.ShowDialog() ?? false)
                 {
                     Crashes.NotifyUserConfirmation(dialog.ClickResult);
                 }
-            }));
+            });
             return true;
         }
 

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -61,7 +61,7 @@ namespace Contoso.WPF.Demo
             var report = e.Report;
             if (report.Exception != null)
             {
-                Log(report.Exception.ToString());
+                Log($"ErrorId: {report.Id}");
             }
         }
 
@@ -71,7 +71,7 @@ namespace Contoso.WPF.Demo
             var report = e.Report;
             if (report.Exception != null)
             {
-                Log(report.Exception.ToString());
+                Log($"ErrorId: {report.Id}");
             }
             else
             {
@@ -85,7 +85,7 @@ namespace Contoso.WPF.Demo
             var report = e.Report;
             if (report.Exception != null)
             {
-                Log(report.Exception.ToString());
+                Log($"ErrorId: {report.Id}");
             }
             if (e.Exception != null)
             {

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -4,6 +4,7 @@
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
+using System;
 using System.Windows;
 
 namespace Contoso.WPF.Demo
@@ -13,10 +14,90 @@ namespace Contoso.WPF.Demo
     /// </summary>
     public partial class App
     {
+        private const string LogTag = "AppCenterSasquatch";
+
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
+            Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
+            Crashes.ShouldProcessErrorReport = ShouldProcess;
+
+            // Event handlers
+            Crashes.SendingErrorReport += SendingErrorReportHandler;
+            Crashes.SentErrorReport += SentErrorReportHandler;
+            Crashes.FailedToSendErrorReport += FailedToSendErrorReportHandler;
             AppCenter.Start("f4e2a83d-3052-4884-8176-8b2c50277d16", typeof(Analytics), typeof(Crashes));
+            Crashes.HasCrashedInLastSessionAsync().ContinueWith(hasCrashed =>
+            {
+                AppCenterLog.Info(LogTag, "Crashes.HasCrashedInLastSession=" + hasCrashed.Result);
+            });
+            Crashes.GetLastSessionCrashReportAsync().ContinueWith(task =>
+            {
+                AppCenterLog.Info(LogTag, "Crashes.LastSessionCrashReport.Exception=" + task.Result?.Exception);
+            });
+        }
+
+        bool ShouldProcess(ErrorReport report)
+        {
+            AppCenterLog.Info(LogTag, "Determining whether to process error report");
+            return true;
+        }
+
+        bool ConfirmationHandler()
+        {
+            Current.Dispatcher.Invoke(new Action(() =>
+            {
+                var dialog = new UserConfirmationDialog();
+                if (dialog.ShowDialog() == true)
+                {
+                    Crashes.NotifyUserConfirmation(dialog.ClickResult);
+                }
+            }));
+            return true;
+        }
+
+        static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
+        {
+            AppCenterLog.Info(LogTag, "Sending error report");
+            var report = e.Report;
+
+            // Test some values
+            if (report.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, report.Exception.ToString());
+            }
+        }
+
+        static void SentErrorReportHandler(object sender, SentErrorReportEventArgs e)
+        {
+            AppCenterLog.Info(LogTag, "Sent error report");
+            var report = e.Report;
+
+            // Test some values
+            if (report.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, report.Exception.ToString());
+            }
+            else
+            {
+                AppCenterLog.Info(LogTag, "No system exception was found");
+            }
+        }
+
+        static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
+        {
+            AppCenterLog.Info(LogTag, "Failed to send error report");
+            var report = e.Report;
+
+            // Test some values
+            if (report.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, report.Exception.ToString());
+            }
+            if (e.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, "There is an exception associated with the failure");
+            }
         }
     }
 }

--- a/Apps/Contoso.WPF.Demo/Contoso.WPF.Demo.csproj
+++ b/Apps/Contoso.WPF.Demo/Contoso.WPF.Demo.csproj
@@ -56,6 +56,9 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Property.cs" />
+    <Compile Include="UserConfirmationDialog.xaml.cs">
+      <DependentUpon>UserConfirmationDialog.xaml</DependentUpon>
+    </Compile>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -68,6 +71,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="UserConfirmationDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace Contoso.WPF.Demo
         private void UpdateState()
         {
             AppCenterEnabled.IsChecked = AppCenter.IsEnabledAsync().Result;
+            CrashesEnabled.IsChecked = Crashes.IsEnabledAsync().Result;
             AnalyticsEnabled.IsChecked = Analytics.IsEnabledAsync().Result;
         }
 

--- a/Apps/Contoso.WPF.Demo/UserConfirmationDialog.xaml
+++ b/Apps/Contoso.WPF.Demo/UserConfirmationDialog.xaml
@@ -1,0 +1,26 @@
+﻿<Window x:Class="Contoso.WPF.Demo.UserConfirmationDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Contoso.WPF.Demo"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        mc:Ignorable="d"
+        Title="Unexpected crash found" Height="150" Width="350">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <Label Margin="8,16,8,8" Name="DescriptionLable" >
+            <Label.Content>
+                <TextBlock TextWrapping="Wrap">Would you like to send an anonymous report so we can fix the problem?</TextBlock>
+            </Label.Content>
+        </Label>
+        <StackPanel Margin="0, 0, 0, 16" VerticalAlignment="Bottom" HorizontalAlignment="Center" Orientation="Horizontal" Height="29">
+            <Button Width="100" Click="SendButton_Click" Margin="2" Content="Send"/>
+            <Button Width="100" Click="AlwaysSendButton_Click" Margin="2" Content="Always Send"/>
+            <Button Width="100" Click="DontSendButton_Click" Margin="2" Content="Don't send"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Apps/Contoso.WPF.Demo/UserConfirmationDialog.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/UserConfirmationDialog.xaml.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AppCenter.Crashes;
+using System.Windows;
+
+namespace Contoso.WPF.Demo
+{
+    public partial class UserConfirmationDialog : Window
+    {
+        public UserConfirmationDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void DontSendButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClickResult = UserConfirmation.DontSend;
+            DialogResult = true;
+        }
+
+        private void AlwaysSendButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClickResult = UserConfirmation.AlwaysSend;
+            DialogResult = true;
+        }
+
+        private void SendButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClickResult = UserConfirmation.Send;
+            DialogResult = true;
+        }
+
+        public UserConfirmation ClickResult { get; private set; }
+    }
+}

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Globalization;
+using System.Windows;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.AppCenter.Crashes;
-using System;
-using System.Windows;
 
 namespace Contoso.WPF.Puppet
 {
@@ -14,8 +15,6 @@ namespace Contoso.WPF.Puppet
     /// </summary>
     public partial class App
     {
-        private const string LogTag = "AppCenterPuppet";
-
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
@@ -30,21 +29,21 @@ namespace Contoso.WPF.Puppet
             AppCenter.Start("42f4a839-c54c-44da-8072-a2f2a61751b2", typeof(Analytics), typeof(Crashes));
             Crashes.HasCrashedInLastSessionAsync().ContinueWith(hasCrashed =>
             {
-                AppCenterLog.Info(LogTag, "Crashes.HasCrashedInLastSession=" + hasCrashed.Result);
+                Log("Crashes.HasCrashedInLastSession=" + hasCrashed.Result);
             });
             Crashes.GetLastSessionCrashReportAsync().ContinueWith(task =>
             {
-                AppCenterLog.Info(LogTag, "Crashes.LastSessionCrashReport.Exception=" + task.Result?.Exception);
+                Log("Crashes.LastSessionCrashReport.Exception=" + task.Result?.Exception);
             });
         }
 
-        bool ShouldProcess(ErrorReport report)
+        private static bool ShouldProcess(ErrorReport report)
         {
-            AppCenterLog.Info(LogTag, "Determining whether to process error report");
+            Log("Determining whether to process error report");
             return true;
         }
 
-        bool ConfirmationHandler()
+        private static bool ConfirmationHandler()
         {
             Current.Dispatcher.Invoke(() =>
             {
@@ -57,42 +56,48 @@ namespace Contoso.WPF.Puppet
             return true;
         }
 
-        static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
+        private static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
         {
-            AppCenterLog.Info(LogTag, "Sending error report");
+            Log("Sending error report");
             var report = e.Report;
             if (report.Exception != null)
             {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
+                Log(report.Exception.ToString());
             }
         }
 
-        static void SentErrorReportHandler(object sender, SentErrorReportEventArgs e)
+        private static void SentErrorReportHandler(object sender, SentErrorReportEventArgs e)
         {
-            AppCenterLog.Info(LogTag, "Sent error report");
+            Log("Sent error report");
             var report = e.Report;
             if (report.Exception != null)
             {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
+                Log(report.Exception.ToString());
             }
             else
             {
-                AppCenterLog.Info(LogTag, "No system exception was found");
+                Log("No system exception was found");
             }
         }
 
-        static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
+        private static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
         {
-            AppCenterLog.Info(LogTag, "Failed to send error report");
+            Log("Failed to send error report");
             var report = e.Report;
             if (report.Exception != null)
             {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
+                Log(report.Exception.ToString());
             }
             if (e.Exception != null)
             {
-                AppCenterLog.Info(LogTag, "There is an exception associated with the failure");
+                Log("There is an exception associated with the failure");
             }
+        }
+
+        private static void Log(string message)
+        {
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
+            System.Diagnostics.Debug.WriteLine($"{timestamp} [AppCenterPuppet] Info: {message}");
         }
     }
 }

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -14,7 +14,7 @@ namespace Contoso.WPF.Puppet
     /// </summary>
     public partial class App
     {
-        private const string LogTag = "AppCenterSasquatch";
+        private const string LogTag = "AppCenterPuppet";
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -23,7 +23,7 @@ namespace Contoso.WPF.Puppet
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
             Crashes.ShouldProcessErrorReport = ShouldProcess;
 
-            // Event handlers
+            // Event handlers.
             Crashes.SendingErrorReport += SendingErrorReportHandler;
             Crashes.SentErrorReport += SentErrorReportHandler;
             Crashes.FailedToSendErrorReport += FailedToSendErrorReportHandler;
@@ -61,8 +61,6 @@ namespace Contoso.WPF.Puppet
         {
             AppCenterLog.Info(LogTag, "Sending error report");
             var report = e.Report;
-
-            // Test some values
             if (report.Exception != null)
             {
                 AppCenterLog.Info(LogTag, report.Exception.ToString());
@@ -73,8 +71,6 @@ namespace Contoso.WPF.Puppet
         {
             AppCenterLog.Info(LogTag, "Sent error report");
             var report = e.Report;
-
-            // Test some values
             if (report.Exception != null)
             {
                 AppCenterLog.Info(LogTag, report.Exception.ToString());
@@ -89,8 +85,6 @@ namespace Contoso.WPF.Puppet
         {
             AppCenterLog.Info(LogTag, "Failed to send error report");
             var report = e.Report;
-
-            // Test some values
             if (report.Exception != null)
             {
                 AppCenterLog.Info(LogTag, report.Exception.ToString());

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -46,14 +46,14 @@ namespace Contoso.WPF.Puppet
 
         bool ConfirmationHandler()
         {
-            Current.Dispatcher.Invoke(new Action(() =>
+            Current.Dispatcher.Invoke(() =>
             {
                 var dialog = new UserConfirmationDialog();
-                if (dialog.ShowDialog() == true)
+                if (dialog.ShowDialog() ?? false)
                 {
                     Crashes.NotifyUserConfirmation(dialog.ClickResult);
                 }
-            }));
+            });
             return true;
         }
 

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -14,14 +14,91 @@ namespace Contoso.WPF.Puppet
     /// </summary>
     public partial class App
     {
+        private const string LogTag = "AppCenterSasquatch";
+
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
-            Crashes.SendingErrorReport += (sender, args) => Console.WriteLine($@"[App] Sending report Id={args.Report.Id} Exception={args.Report.Exception}");
-            Crashes.SentErrorReport += (sender, args) => Console.WriteLine($@"[App] Sent report Id={args.Report.Id}");
-            Crashes.FailedToSendErrorReport += (sender, args) => Console.WriteLine($@"[App] FailedToSend report Id={args.Report.Id} Error={args.Exception}");
+            Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
+            Crashes.ShouldProcessErrorReport = ShouldProcess;
+
+            // Event handlers
+            Crashes.SendingErrorReport += SendingErrorReportHandler;
+            Crashes.SentErrorReport += SentErrorReportHandler;
+            Crashes.FailedToSendErrorReport += FailedToSendErrorReportHandler;
             AppCenter.Start("42f4a839-c54c-44da-8072-a2f2a61751b2", typeof(Analytics), typeof(Crashes));
+            Crashes.HasCrashedInLastSessionAsync().ContinueWith(hasCrashed =>
+            {
+                AppCenterLog.Info(LogTag, "Crashes.HasCrashedInLastSession=" + hasCrashed.Result);
+            });
+            Crashes.GetLastSessionCrashReportAsync().ContinueWith(task =>
+            {
+                AppCenterLog.Info(LogTag, "Crashes.LastSessionCrashReport.Exception=" + task.Result?.Exception);
+            });
+        }
+
+        bool ShouldProcess(ErrorReport report)
+        {
+            AppCenterLog.Info(LogTag, "Determining whether to process error report");
+            return true;
+        }
+
+        bool ConfirmationHandler()
+        {
+            Current.Dispatcher.Invoke(new Action(() =>
+            {
+                var dialog = new UserConfirmationDialog();
+                if (dialog.ShowDialog() == true)
+                {
+                    Crashes.NotifyUserConfirmation(dialog.ClickResult);
+                }
+            }));
+            return true;
+        }
+
+        static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
+        {
+            AppCenterLog.Info(LogTag, "Sending error report");
+            var report = e.Report;
+
+            // Test some values
+            if (report.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, report.Exception.ToString());
+            }
+        }
+
+        static void SentErrorReportHandler(object sender, SentErrorReportEventArgs e)
+        {
+            AppCenterLog.Info(LogTag, "Sent error report");
+            var report = e.Report;
+
+            // Test some values
+            if (report.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, report.Exception.ToString());
+            }
+            else
+            {
+                AppCenterLog.Info(LogTag, "No system exception was found");
+            }
+        }
+
+        static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
+        {
+            AppCenterLog.Info(LogTag, "Failed to send error report");
+            var report = e.Report;
+
+            // Test some values
+            if (report.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, report.Exception.ToString());
+            }
+            if (e.Exception != null)
+            {
+                AppCenterLog.Info(LogTag, "There is an exception associated with the failure");
+            }
         }
     }
 }

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -62,7 +62,7 @@ namespace Contoso.WPF.Puppet
             var report = e.Report;
             if (report.Exception != null)
             {
-                Log(report.Exception.ToString());
+                Log($"ErrorId: {report.Id}");
             }
         }
 
@@ -72,7 +72,7 @@ namespace Contoso.WPF.Puppet
             var report = e.Report;
             if (report.Exception != null)
             {
-                Log(report.Exception.ToString());
+                Log($"ErrorId: {report.Id}");
             }
             else
             {
@@ -86,7 +86,7 @@ namespace Contoso.WPF.Puppet
             var report = e.Report;
             if (report.Exception != null)
             {
-                Log(report.Exception.ToString());
+                Log($"ErrorId: {report.Id}");
             }
             if (e.Exception != null)
             {

--- a/Apps/Contoso.WPF.Puppet/Contoso.WPF.Puppet.csproj
+++ b/Apps/Contoso.WPF.Puppet/Contoso.WPF.Puppet.csproj
@@ -61,6 +61,9 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Property.cs" />
+    <Compile Include="UserConfirmationDialog.xaml.cs">
+      <DependentUpon>UserConfirmationDialog.xaml</DependentUpon>
+    </Compile>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -73,6 +76,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="UserConfirmationDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/Apps/Contoso.WPF.Puppet/UserConfirmationDialog.xaml
+++ b/Apps/Contoso.WPF.Puppet/UserConfirmationDialog.xaml
@@ -1,0 +1,26 @@
+﻿<Window x:Class="Contoso.WPF.Puppet.UserConfirmationDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Contoso.WPF.Puppet"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        mc:Ignorable="d"
+        Title="Unexpected crash found" Height="150" Width="350">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <Label Margin="8,16,8,8" Name="DescriptionLable" >
+            <Label.Content>
+                <TextBlock TextWrapping="Wrap">Would you like to send an anonymous report so we can fix the problem?</TextBlock>
+            </Label.Content>
+        </Label>
+        <StackPanel Margin="0, 0, 0, 16" VerticalAlignment="Bottom" HorizontalAlignment="Center" Orientation="Horizontal" Height="29">
+            <Button Width="100" Click="SendButton_Click" Margin="2" Content="Send"/>
+            <Button Width="100" Click="AlwaysSendButton_Click" Margin="2" Content="Always Send"/>
+            <Button Width="100" Click="DontSendButton_Click" Margin="2" Content="Don't send"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Apps/Contoso.WPF.Puppet/UserConfirmationDialog.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/UserConfirmationDialog.xaml.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AppCenter.Crashes;
+using System.Windows;
+
+namespace Contoso.WPF.Puppet
+{
+    public partial class UserConfirmationDialog : Window
+    {
+        public UserConfirmationDialog()
+        {
+            InitializeComponent();
+        }
+
+        private void DontSendButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClickResult = UserConfirmation.DontSend;
+            DialogResult = true;
+        }
+
+        private void AlwaysSendButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClickResult = UserConfirmation.AlwaysSend;
+            DialogResult = true;
+        }
+
+        private void SendButton_Click(object sender, RoutedEventArgs e)
+        {
+            ClickResult = UserConfirmation.Send;
+            DialogResult = true;
+        }
+
+        public UserConfirmation ClickResult { get; private set; }
+    }
+}


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the UWP implementation?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add functionality to the WPF app for the following APIs: Events/callbacks, HasCrashedInLastSession, GetLastSessionErrorReportAsync, and user confirmation.

![image](https://user-images.githubusercontent.com/42138465/60806980-1ec1f880-a18d-11e9-85c9-dcb3e9e1f604.png)


## Related PRs or issues

[AB#63633](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63633)