### PR TITLE
[Fix] Both forms app send 1 push log for every character typed in userId field

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -44,12 +44,14 @@ namespace Contoso.Forms.Demo
                 Crashes.GetErrorAttachments = GetErrorAttachments;
                 Distribute.ReleaseAvailable = OnReleaseAvailable;
                 Push.PushNotificationReceived += OnPushNotificationReceived;
-                AppCenter.Start($"uwp={uwpKey};android={androidKey};ios={iosKey}",
-                                   typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Push), typeof(Auth), typeof(Data));
+                AppCenter.Start($"uwp={uwpKey};android={androidKey};ios={iosKey}", typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Auth), typeof(Data));
                 if (Current.Properties.ContainsKey(Constants.UserId) && Current.Properties[Constants.UserId] is string id)
                 {
                     AppCenter.SetUserId(id);
                 }
+
+                // Work around for SetUserId race condition.
+                AppCenter.Start(typeof(Push));
                 AppCenter.GetInstallIdAsync().ContinueWith(installId =>
                 {
                     AppCenterLog.Info(LogTag, "AppCenter.InstallId=" + installId.Result);

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -46,7 +46,7 @@ namespace Contoso.Forms.Demo
                 Push.PushNotificationReceived += OnPushNotificationReceived;
                 AppCenter.Start($"uwp={uwpKey};android={androidKey};ios={iosKey}",
                                    typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Push), typeof(Auth), typeof(Data));
-                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
+                if (Current.Properties.ContainsKey(Constants.UserId) && Current.Properties[Constants.UserId] is string id)
                 {
                     AppCenter.SetUserId(id);
                 }

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Constants.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Constants.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace Contoso.Forms.Demo
+{
+    [Android.Runtime.Preserve(AllMembers = true)]
+    public static class Constants
+    {
+        public const string UserId = "userId";
+    }
+}

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Constants.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Constants.cs
@@ -1,8 +1,5 @@
-﻿using System;
-
-namespace Contoso.Forms.Demo
+﻿namespace Contoso.Forms.Demo
 {
-    [Android.Runtime.Preserve(AllMembers = true)]
     public static class Constants
     {
         public const string UserId = "userId";

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Constants.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Constants.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 namespace Contoso.Forms.Demo
 {
     [Android.Runtime.Preserve(AllMembers = true)]

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
@@ -1,17 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage Title="App Center" xmlns:local="clr-namespace:Contoso.Forms.Demo"
-             xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Contoso.Forms.Demo.AppCenterContentPage">
+<ContentPage Title="App Center" xmlns:local="clr-namespace:Contoso.Forms.Demo" xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Contoso.Forms.Demo.AppCenterContentPage">
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
-            <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="{StaticResource SwitchCellOnColor}"/>
+            <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="{StaticResource SwitchCellOnColor}" />
         </TableSection>
         <TableSection Title="Logging">
             <ViewCell>
                 <StackLayout Orientation="Horizontal" Margin="15,0,15,0">
-                   <Label Text="User Id" HorizontalOptions="FillAndExpand" VerticalOptions="Center" />
-                   <Entry x:Name="UserIdEntry" HorizontalOptions="FillAndExpand" VerticalOptions="Center" HorizontalTextAlignment="End"/>
+                    <Label Text="User Id" HorizontalOptions="FillAndExpand" VerticalOptions="Center" />
+                    <Entry x:Name="UserIdEntry" HorizontalOptions="FillAndExpand" VerticalOptions="Center" HorizontalTextAlignment="End" />
                 </StackLayout>
             </ViewCell>
         </TableSection>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml
@@ -1,17 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage Title="App Center" xmlns:local="clr-namespace:Contoso.Forms.Demo"
              xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Contoso.Forms.Demo.AppCenterContentPage">
-    <ContentPage.BindingContext>
-        <local:EntryCellTextChanged />
-    </ContentPage.BindingContext>
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
             <SwitchCell Text="AppCenter Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" OnColor="{StaticResource SwitchCellOnColor}"/>
         </TableSection>
         <TableSection Title="Logging">
-            <EntryCell Label="User Id" x:Name="UserIdEntryCell" HorizontalTextAlignment="End" Text="{Binding UserId,Mode=TwoWay}" />
+            <ViewCell>
+                <StackLayout Orientation="Horizontal" Margin="15,0,15,0">
+                   <Label Text="User Id" HorizontalOptions="FillAndExpand" VerticalOptions="Center" />
+                   <Entry x:Name="UserIdEntry" HorizontalOptions="FillAndExpand" VerticalOptions="Center" HorizontalTextAlignment="End"/>
+                </StackLayout>
+            </ViewCell>
         </TableSection>
     </TableView>
 </ContentPage>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -24,6 +24,10 @@ namespace Contoso.Forms.Demo
         {
             base.OnAppearing();
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
+            if (Application.Current.Properties.ContainsKey(Constants.UserId) && Application.Current.Properties[Constants.UserId] is string id)
+            {
+                UserIdEntry.Text = id;
+            }
             UserIdEntry.Unfocused += (sender, args) =>
             {
                 var inputText = UserIdEntry.Text;

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -24,53 +24,18 @@ namespace Contoso.Forms.Demo
         {
             base.OnAppearing();
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
+            UserIdEntry.Unfocused += (sender, args) =>
+            {
+                var inputText = UserIdEntry.Text;
+                var text = string.IsNullOrEmpty(inputText) ? null : inputText;
+                AppCenter.SetUserId(text);
+                Application.Current.Properties[Constants.UserId] = text;
+            };
         }
 
         async void UpdateEnabled(object sender, ToggledEventArgs e)
         {
             await AppCenter.SetEnabledAsync(e.Value);
-        }
-    }
-
-    [Android.Runtime.Preserve(AllMembers = true)]
-    public class EntryCellTextChanged : INotifyPropertyChanged
-    {
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        internal static string UserIdKey = "userId";
-
-        private string _userId;
-
-        public EntryCellTextChanged()
-        {
-            if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
-            {
-                UserId = id;
-            }
-        }
-
-        public string UserId
-        {
-            get { return _userId; }
-
-            set
-            {
-                _userId = value;
-                OnTextChanged(_userId);
-            }
-        }
-
-        public ICommand TextChanged;
-
-        protected virtual void OnTextChanged(string inputText)
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(inputText));
-                var text = string.IsNullOrEmpty(inputText) ? null : inputText;
-                AppCenter.SetUserId(text);
-                Application.Current.Properties[UserIdKey] = text;
-            }
         }
     }
 }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="60" android:versionName="2.2.0-SNAPSHOT" package="com.microsoft.appcenter.xamarin.forms.puppet">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
 	<application android:label="ACFPuppet">

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -60,7 +60,7 @@ namespace Contoso.Forms.Puppet
                 Auth.SetConfigUrl("https://config-integration.dev.avalanch.es");
                 Data.SetTokenExchangeUrl("https://token-exchange-mbaas-integration.dev.avalanch.es/v0.1");
                 AppCenter.Start($"uwp={UwpKey};android={AndroidKey};ios={IosKey}", typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Push), typeof(Auth), typeof(Data));
-                if (Current.Properties.ContainsKey(EntryCellTextChanged.UserIdKey) && Current.Properties[EntryCellTextChanged.UserIdKey] is string id)
+                if (Current.Properties.ContainsKey(Constants.UserId) && Current.Properties[Constants.UserId] is string id)
                 {
                     AppCenter.SetUserId(id);
                 }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -54,16 +54,19 @@ namespace Contoso.Forms.Puppet
 
                 AppCenterLog.Assert(LogTag, "AppCenter.Configured=" + AppCenter.Configured);
                 AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
-               
+
                 Distribute.SetInstallUrl("https://install.portal-server-core-integration.dev.avalanch.es");
                 Distribute.SetApiUrl("https://api-gateway-core-integration.dev.avalanch.es/v0.1");
                 Auth.SetConfigUrl("https://config-integration.dev.avalanch.es");
                 Data.SetTokenExchangeUrl("https://token-exchange-mbaas-integration.dev.avalanch.es/v0.1");
-                AppCenter.Start($"uwp={UwpKey};android={AndroidKey};ios={IosKey}", typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Push), typeof(Auth), typeof(Data));
+                AppCenter.Start($"uwp={UwpKey};android={AndroidKey};ios={IosKey}", typeof(Analytics), typeof(Crashes), typeof(Distribute), typeof(Auth), typeof(Data));
                 if (Current.Properties.ContainsKey(Constants.UserId) && Current.Properties[Constants.UserId] is string id)
                 {
                     AppCenter.SetUserId(id);
                 }
+
+                // Work around for SetUserId race condition.
+                AppCenter.Start(typeof(Push));
                 AppCenter.IsEnabledAsync().ContinueWith(enabled =>
                 {
                     AppCenterLog.Info(LogTag, "AppCenter.Enabled=" + enabled.Result);

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Constants.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/Constants.cs
@@ -12,5 +12,6 @@ namespace Contoso.Forms.Puppet
         public const string Warning = "Warning";
         public const string Error = "Error";
         public const string BingMapsAuthKey = "paste-key-here";
+        public const string UserId = "userId";
     }
 }

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml
@@ -1,11 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage Title="App Center"
              xmlns:local="clr-namespace:Contoso.Forms.Puppet"
              xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Contoso.Forms.Puppet.AppCenterContentPage">
-    <ContentPage.BindingContext>
-        <local:EntryCellTextChanged/>
-    </ContentPage.BindingContext>
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
             <SwitchCell Text="App Center Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled"/>
@@ -30,7 +27,12 @@
             </ViewCell>
         </TableSection>
         <TableSection Title="Logging">
-            <EntryCell Label="User Id" x:Name="UserIdEntryCell" Text="{Binding UserId, Mode=TwoWay}" HorizontalTextAlignment="End"/>
+            <ViewCell>
+                <StackLayout Orientation="Horizontal" Margin="15,0,15,0">
+                   <Label Text="User Id" HorizontalOptions="FillAndExpand" VerticalOptions="Center" />
+                   <Entry x:Name="UserIdEntry" HorizontalOptions="FillAndExpand" VerticalOptions="Center" HorizontalTextAlignment="End"/>
+                </StackLayout>
+            </ViewCell>
         </TableSection>
     </TableView>
 </ContentPage>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml
@@ -1,11 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage Title="App Center"
-             xmlns:local="clr-namespace:Contoso.Forms.Puppet"
-             xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Contoso.Forms.Puppet.AppCenterContentPage">
+<ContentPage Title="App Center" xmlns:local="clr-namespace:Contoso.Forms.Puppet" xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Contoso.Forms.Puppet.AppCenterContentPage">
     <TableView Intent="Form">
         <TableSection Title="AppCenter Settings">
-            <SwitchCell Text="App Center Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled"/>
+            <SwitchCell Text="App Center Enabled" On="true" x:Name="AppCenterEnabledSwitchCell" OnChanged="UpdateEnabled" />
             <ViewCell Tapped="LogLevelCellTapped">
                 <StackLayout Orientation="Horizontal" Margin="15,0,15,0">
                     <Label Text="Log Level" HorizontalOptions="StartAndExpand" VerticalOptions="Center" />
@@ -14,8 +11,8 @@
             </ViewCell>
         </TableSection>
         <TableSection Title="Logging">
-            <EntryCell Label="Log Message" x:Name="LogMessageEntryCell"/>
-            <EntryCell Label="Log Tag" x:Name="LogTagEntryCell"/>
+            <EntryCell Label="Log Message" x:Name="LogMessageEntryCell" />
+            <EntryCell Label="Log Tag" x:Name="LogTagEntryCell" />
             <ViewCell Tapped="LogWriteLevelCellTapped">
                 <StackLayout Orientation="Horizontal" Margin="15,0,15,0">
                     <Label Text="Log Level" HorizontalOptions="StartAndExpand" VerticalOptions="Center" />
@@ -23,14 +20,14 @@
                 </StackLayout>
             </ViewCell>
             <ViewCell Tapped="WriteLog">
-                <Button Text="Write Log" InputTransparent="true" Clicked="WriteLog"/>
+                <Button Text="Write Log" InputTransparent="true" Clicked="WriteLog" />
             </ViewCell>
         </TableSection>
         <TableSection Title="Logging">
             <ViewCell>
                 <StackLayout Orientation="Horizontal" Margin="15,0,15,0">
-                   <Label Text="User Id" HorizontalOptions="FillAndExpand" VerticalOptions="Center" />
-                   <Entry x:Name="UserIdEntry" HorizontalOptions="FillAndExpand" VerticalOptions="Center" HorizontalTextAlignment="End"/>
+                    <Label Text="User Id" HorizontalOptions="FillAndExpand" VerticalOptions="Center" />
+                    <Entry x:Name="UserIdEntry" HorizontalOptions="FillAndExpand" VerticalOptions="Center" HorizontalTextAlignment="End" />
                 </StackLayout>
             </ViewCell>
         </TableSection>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -53,6 +53,10 @@ namespace Contoso.Forms.Puppet
             base.OnAppearing();
             LogLevelLabel.Text = LogLevelNames[AppCenter.LogLevel];
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
+            if (Application.Current.Properties.ContainsKey(Constants.UserId) && Application.Current.Properties[Constants.UserId] is string id)
+            {
+                UserIdEntry.Text = id;
+            }
             UserIdEntry.Unfocused += (sender, args) =>
             {
                 var inputText = UserIdEntry.Text;

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -53,7 +53,13 @@ namespace Contoso.Forms.Puppet
             base.OnAppearing();
             LogLevelLabel.Text = LogLevelNames[AppCenter.LogLevel];
             AppCenterEnabledSwitchCell.On = await AppCenter.IsEnabledAsync();
-
+            UserIdEntry.Unfocused += (sender, args) =>
+            {
+                var inputText = UserIdEntry.Text;
+                var text = string.IsNullOrEmpty(inputText) ? null : inputText;
+                AppCenter.SetUserId(text);
+                Application.Current.Properties[Constants.UserId] = text;
+            };
         }
 
         void LogLevelCellTapped(object sender, EventArgs e)
@@ -92,48 +98,6 @@ namespace Contoso.Forms.Puppet
         void UpdateLogWriteLevelLabel()
         {
             LogWriteLevelLabel.Text = LogLevelNames[LogWriteLevel];
-        }
-    }
-
-    [Android.Runtime.Preserve(AllMembers = true)]
-    public class EntryCellTextChanged : INotifyPropertyChanged
-    {
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        internal static string UserIdKey = "userId";
-
-        private string _userId;
-
-        public EntryCellTextChanged()
-        {
-            if (Application.Current.Properties.ContainsKey(UserIdKey) && Application.Current.Properties[UserIdKey] is string id)
-            {
-                UserId = id;
-            }
-        }
-
-        public string UserId
-        {
-            get { return _userId; }
-
-            set
-            {
-                _userId = value;
-                OnTextChanged(_userId);
-            }
-        }
-
-        public ICommand TextChanged;
-
-        protected virtual void OnTextChanged(string inputText)
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(inputText));
-                var text = string.IsNullOrEmpty(inputText) ? null : inputText;
-                AppCenter.SetUserId(text);
-                Application.Current.Properties[UserIdKey] = text;
-            }
         }
     }
 }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Use either Contoso.Forms.Puppet or Contoso.Forms.Demo on Android or iOS.
Type characters in userId.

Expected: push log sent only when done typing.
Actual: 1 push log sent for every typed character.

## Related PRs or issues

[AB#64145](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/64145)
