### PR TITLE
Crash logs a warning with exception when starting in disabled mode

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/Files/Directory.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Utils/Files/Directory.cs
@@ -53,5 +53,10 @@ namespace Microsoft.AppCenter.Utils.Files
         {
             return _underlyingDirectoryInfo.Exists;
         }
+
+        public virtual void Refresh()
+        {
+            _underlyingDirectoryInfo.Refresh();
+        }
     }
 }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
@@ -305,19 +305,23 @@ namespace Microsoft.AppCenter.Crashes.Utils
 
         public virtual void InstanceRemoveAllStoredErrorLogFiles()
         {
-            lock (LockObject)
+            // Crashes directory will not exist if disabling has already deleted the folder.
+            if (_crashesDirectory.Exists())
             {
-                AppCenterLog.Debug(Crashes.LogTag, $"Deleting error log directory.");
-                try
+                lock (LockObject)
                 {
-                    _crashesDirectory.Delete(true);
+                    AppCenterLog.Debug(Crashes.LogTag, $"Deleting error log directory.");
+                    try
+                    {
+                        _crashesDirectory.Delete(true);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        AppCenterLog.Warn(Crashes.LogTag, $"Failed to delete error log directory.", ex);
+                    }
                 }
-                catch (System.Exception ex)
-                {
-                    AppCenterLog.Warn(Crashes.LogTag, $"Failed to delete error log directory.", ex);
-                }
+                AppCenterLog.Debug(Crashes.LogTag, "Deleted crashes local files.");
             }
-            AppCenterLog.Debug(Crashes.LogTag, "Deleted crashes local files.");
         }
 
         private static ModelException CreateModelException(System.Exception exception)

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Utils/ErrorLogHelper.cs
@@ -305,10 +305,12 @@ namespace Microsoft.AppCenter.Crashes.Utils
 
         public virtual void InstanceRemoveAllStoredErrorLogFiles()
         {
-            // Crashes directory will not exist if disabling has already deleted the folder.
-            if (_crashesDirectory.Exists())
+            lock (LockObject)
             {
-                lock (LockObject)
+                _crashesDirectory.Refresh();
+
+                // Crashes directory will not exist if disabling has already deleted the folder.
+                if (_crashesDirectory.Exists())
                 {
                     AppCenterLog.Debug(Crashes.LogTag, $"Deleting error log directory.");
                     try
@@ -319,8 +321,8 @@ namespace Microsoft.AppCenter.Crashes.Utils
                     {
                         AppCenterLog.Warn(Crashes.LogTag, $"Failed to delete error log directory.", ex);
                     }
+                    AppCenterLog.Debug(Crashes.LogTag, "Deleted crashes local files.");
                 }
-                AppCenterLog.Debug(Crashes.LogTag, "Deleted crashes local files.");
             }
         }
 

--- a/Tests/Microsoft.AppCenter.Crashes.Test.Windows/Utils/ErrorLogHelperTest.cs
+++ b/Tests/Microsoft.AppCenter.Crashes.Test.Windows/Utils/ErrorLogHelperTest.cs
@@ -421,6 +421,7 @@ namespace Microsoft.AppCenter.Crashes.Test.Windows.Utils
         public void RemoveAllStoredErrorLogFiles()
         {
             var mockDirectory = Mock.Of<Directory>();
+            Mock.Get(mockDirectory).Setup(d => d.Exists()).Returns(true);
             ErrorLogHelper.Instance._crashesDirectory = mockDirectory;
             ErrorLogHelper.RemoveAllStoredErrorLogFiles();
             Mock.Get(mockDirectory).Verify(d => d.Delete(true));


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the UWP implementation?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

On startup with Crashes disabled or toggling off Crashes without a crashes directory would WARN with a NotFoundException.

## Related PRs or issues

[AB#64338](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/64338)

## Misc

I also found that toggling the module on and off would throw this warning with every off-toggle even though the directory hadn't been recreated.
Without the `.Refresh()` call, the `.Exists()` call would remain `true` post-delete.
