### PR TITLE
Fix sending error report event triggered twice

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -35,8 +35,7 @@ namespace Contoso.Forms.Demo
             if (!AppCenter.Configured)
             {
                 AppCenter.LogLevel = LogLevel.Verbose;
-                Crashes.SendingErrorReport += SendingErrorReportHandler;
-                Crashes.SendingErrorReport += SendingErrorReportHandler;
+                Crashes.SendingErrorReport += SendingErrorReportHandler; 
                 Crashes.SentErrorReport += SentErrorReportHandler;
                 Crashes.FailedToSendErrorReport += FailedToSendErrorReportHandler;
                 Crashes.ShouldProcessErrorReport = ShouldProcess;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Repro steps:
Use demo.
Crash.
Restart and look at logs.
Sending error report is printed twice.

## Related PRs or issues

[AB#64616](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/64616)
