### PR TITLE
Restore country code after app restart

### DIFF
--- a/Apps/Contoso.WPF.Demo/App.config
+++ b/Apps/Contoso.WPF.Demo/App.config
@@ -16,6 +16,9 @@
             <setting name="FileErrorAttachments" serializeAs="String">
                 <value />
             </setting>
+            <setting name="CountryCode" serializeAs="String">
+                <value />
+            </setting>
         </Contoso.WPF.Demo.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -22,7 +22,10 @@ namespace Contoso.WPF.Demo
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
-            AppCenter.SetCountryCode(Settings.Default.CountryCode);
+            if (!string.IsNullOrEmpty(Settings.Default.CountryCode))
+            {
+                AppCenter.SetCountryCode(Settings.Default.CountryCode);
+            }
 
             // User callbacks.
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -22,10 +22,7 @@ namespace Contoso.WPF.Demo
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
-            if (!string.IsNullOrEmpty(Settings.Default.CountryCode))
-            {
-                AppCenter.SetCountryCode(Settings.Default.CountryCode);
-            }
+            AppCenter.SetCountryCode(string.IsNullOrEmpty(Settings.Default.CountryCode) ? null : Settings.Default.CountryCode);
 
             // User callbacks.
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;

--- a/Apps/Contoso.WPF.Demo/App.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/App.xaml.cs
@@ -22,6 +22,7 @@ namespace Contoso.WPF.Demo
         protected override void OnStartup(StartupEventArgs e)
         {
             AppCenter.LogLevel = LogLevel.Verbose;
+            AppCenter.SetCountryCode(Settings.Default.CountryCode);
 
             // User callbacks.
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml
@@ -125,7 +125,7 @@
                                 </DockPanel>
                             </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
-                            <TextBlock Foreground="Red" Name="InfoLable" TextWrapping="Wrap"/>
+                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code update. Please close the application completely and relaunch it.</TextBlock>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml
@@ -125,7 +125,7 @@
                                 </DockPanel>
                             </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
-                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code update. Please close the application completely and relaunch it.</TextBlock>
+                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code has been updated. Please restart the application.</TextBlock>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml
@@ -125,7 +125,7 @@
                                 </DockPanel>
                             </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
-                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code has been updated. Please restart the application.</TextBlock>
+                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code has been updated. This value will only be applied to the following sessions.</TextBlock>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml
@@ -117,12 +117,15 @@
                 <StackPanel>
                     <CheckBox Name="CountryCodeEnableCheckbox" Content="Country Code Enabled" Margin="0,10,0,10" Checked="CountryCodeEnabled_Checked" Unchecked="CountryCodeEnabled_Checked"/>
                     <GroupBox Header="Country code">
-                        <StackPanel IsEnabled="False" Name="CountryCodePanel">
-                            <DockPanel LastChildFill="True">
-                                <Label Name="CountryCodeLabel">Country code</Label>
-                                <TextBox Name="CountryCodeText"  VerticalAlignment="Center"></TextBox>
-                            </DockPanel>
+                        <StackPanel>
+                            <StackPanel IsEnabled="False" Name="CountryCodePanel">
+                                <DockPanel LastChildFill="True">
+                                    <Label Name="CountryCodeLabel">Country code</Label>
+                                    <TextBox Name="CountryCodeText"  VerticalAlignment="Center"></TextBox>
+                                </DockPanel>
+                            </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
+                            <TextBlock Foreground="Red" Name="InfoLable" TextWrapping="Wrap"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
@@ -141,6 +141,7 @@ namespace Contoso.WPF.Demo
             InfoLable.Visibility = Visibility.Visible;
             Settings.Default.CountryCode = CountryCodeText.Text;
             Settings.Default.Save();
+            AppCenter.SetCountryCode(string.IsNullOrEmpty(Settings.Default.CountryCode) ? null : Settings.Default.CountryCode);
         }
 
         private void FileErrorAttachment_Click(object sender, RoutedEventArgs e)

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
@@ -28,8 +28,6 @@ namespace Contoso.WPF.Demo
 
         private string textAttachments;
 
-        private const string SaveCountryCodeLabelText = "Country code update. Please close the application completely and relaunch it.";
-
         private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions =
             new Dictionary<LogLevel, Action<string, string>>
             {
@@ -140,10 +138,9 @@ namespace Contoso.WPF.Demo
 
         private void CountryCodeSave_ClickListener(object sender, RoutedEventArgs e)
         {
-            InfoLable.Text = SaveCountryCodeLabelText;
+            InfoLable.Visibility = Visibility.Visible;
             Settings.Default.CountryCode = CountryCodeText.Text;
             Settings.Default.Save();
-            AppCenter.SetCountryCode(CountryCodeText.Text.Length > 0 ? CountryCodeText.Text : null);
         }
 
         private void FileErrorAttachment_Click(object sender, RoutedEventArgs e)

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
@@ -52,6 +52,10 @@ namespace Contoso.WPF.Demo
             textAttachments = Settings.Default.TextErrorAttachments;
             TextAttachmentTextBox.Text = textAttachments;
             FileAttachmentLabel.Content = fileAttachments;
+            if (!string.IsNullOrEmpty(Settings.Default.CountryCode))
+            {
+                CountryCodeEnableCheckbox.IsChecked = true;
+            }
         }
 
         private void UpdateState()
@@ -121,14 +125,20 @@ namespace Contoso.WPF.Demo
             }
             else
             {
-                CountryCodeText.Text = RegionInfo.CurrentRegion.TwoLetterISORegionName;
+                CountryCodeText.Text = string.IsNullOrEmpty(Settings.Default.CountryCode)
+                    ? RegionInfo.CurrentRegion.TwoLetterISORegionName
+                    : Settings.Default.CountryCode;
                 AppCenter.SetCountryCode(CountryCodeText.Text);
             }
+            Settings.Default.CountryCode = CountryCodeText.Text;
+            Settings.Default.Save();
             CountryCodePanel.IsEnabled = CountryCodeEnableCheckbox.IsChecked.Value;
         }
 
         private void CountryCodeSave_ClickListener(object sender, RoutedEventArgs e)
         {
+            Settings.Default.CountryCode = CountryCodeText.Text;
+            Settings.Default.Save();
             AppCenter.SetCountryCode(CountryCodeText.Text.Length > 0 ? CountryCodeText.Text : null);
         }
 

--- a/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Demo/MainWindow.xaml.cs
@@ -28,6 +28,8 @@ namespace Contoso.WPF.Demo
 
         private string textAttachments;
 
+        private const string SaveCountryCodeLabelText = "Country code update. Please close the application completely and relaunch it.";
+
         private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions =
             new Dictionary<LogLevel, Action<string, string>>
             {
@@ -121,22 +123,24 @@ namespace Contoso.WPF.Demo
             if (!CountryCodeEnableCheckbox.IsChecked.Value)
             {
                 CountryCodeText.Text = "";
-                AppCenter.SetCountryCode(null);
             }
             else
             {
-                CountryCodeText.Text = string.IsNullOrEmpty(Settings.Default.CountryCode)
-                    ? RegionInfo.CurrentRegion.TwoLetterISORegionName
-                    : Settings.Default.CountryCode;
-                AppCenter.SetCountryCode(CountryCodeText.Text);
+                if (string.IsNullOrEmpty(Settings.Default.CountryCode))
+                {
+                    CountryCodeText.Text = RegionInfo.CurrentRegion.TwoLetterISORegionName;
+                }
+                else
+                {
+                    CountryCodeText.Text = Settings.Default.CountryCode;
+                }
             }
-            Settings.Default.CountryCode = CountryCodeText.Text;
-            Settings.Default.Save();
             CountryCodePanel.IsEnabled = CountryCodeEnableCheckbox.IsChecked.Value;
         }
 
         private void CountryCodeSave_ClickListener(object sender, RoutedEventArgs e)
         {
+            InfoLable.Text = SaveCountryCodeLabelText;
             Settings.Default.CountryCode = CountryCodeText.Text;
             Settings.Default.Save();
             AppCenter.SetCountryCode(CountryCodeText.Text.Length > 0 ? CountryCodeText.Text : null);

--- a/Apps/Contoso.WPF.Demo/Properties/Settings.Designer.cs
+++ b/Apps/Contoso.WPF.Demo/Properties/Settings.Designer.cs
@@ -46,5 +46,17 @@ namespace Contoso.WPF.Demo.Properties {
                 this["FileErrorAttachments"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CountryCode {
+            get {
+                return ((string)(this["CountryCode"]));
+            }
+            set {
+                this["CountryCode"] = value;
+            }
+        }
     }
 }

--- a/Apps/Contoso.WPF.Demo/Properties/Settings.settings
+++ b/Apps/Contoso.WPF.Demo/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="FileErrorAttachments" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="CountryCode" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Apps/Contoso.WPF.Puppet/App.config
+++ b/Apps/Contoso.WPF.Puppet/App.config
@@ -16,6 +16,9 @@
             <setting name="TextErrorAttachments" serializeAs="String">
                 <value />
             </setting>
+            <setting name="CountryCode" serializeAs="String">
+                <value />
+            </setting>
         </Contoso.WPF.Puppet.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -23,7 +23,10 @@ namespace Contoso.WPF.Puppet
         {
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
-            AppCenter.SetCountryCode(Settings.Default.CountryCode);
+            if (!string.IsNullOrEmpty(Settings.Default.CountryCode))
+            {
+                AppCenter.SetCountryCode(Settings.Default.CountryCode);
+            }
 
             // User callbacks.
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -23,10 +23,7 @@ namespace Contoso.WPF.Puppet
         {
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
-            if (!string.IsNullOrEmpty(Settings.Default.CountryCode))
-            {
-                AppCenter.SetCountryCode(Settings.Default.CountryCode);
-            }
+            AppCenter.SetCountryCode(string.IsNullOrEmpty(Settings.Default.CountryCode) ? null : Settings.Default.CountryCode);
 
             // User callbacks.
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;

--- a/Apps/Contoso.WPF.Puppet/App.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/App.xaml.cs
@@ -23,6 +23,7 @@ namespace Contoso.WPF.Puppet
         {
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
+            AppCenter.SetCountryCode(Settings.Default.CountryCode);
 
             // User callbacks.
             Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -125,7 +125,7 @@
                                 </DockPanel>
                             </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
-                            <TextBlock Foreground="Red" Name="InfoLable" TextWrapping="Wrap"/>
+                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code update. Please close the application completely and relaunch it.</TextBlock>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -125,7 +125,7 @@
                                 </DockPanel>
                             </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
-                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code update. Please close the application completely and relaunch it.</TextBlock>
+                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code has been updated. Please restart the application.</TextBlock>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -125,7 +125,7 @@
                                 </DockPanel>
                             </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
-                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code has been updated. Please restart the application.</TextBlock>
+                            <TextBlock Visibility="Collapsed" Foreground="Red" Name="InfoLable" TextWrapping="Wrap">Country code has been updated. This value will only be applied to the following sessions.</TextBlock>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml
@@ -117,12 +117,15 @@
                 <StackPanel>
                     <CheckBox Name="CountryCodeEnableCheckbox" Content="Country Code Enabled" Margin="0,10,0,10" Checked="CountryCodeEnabled_Checked" Unchecked="CountryCodeEnabled_Checked"/>
                     <GroupBox Header="Country code">
-                        <StackPanel IsEnabled="False" Name="CountryCodePanel">
-                            <DockPanel LastChildFill="True">
-                                <Label Name="CountryCodeLabel">Country code</Label>
-                                <TextBox Name="CountryCodeText"  VerticalAlignment="Center"></TextBox>
-                            </DockPanel>
+                        <StackPanel>
+                            <StackPanel IsEnabled="False" Name="CountryCodePanel">
+                                <DockPanel LastChildFill="True">
+                                    <Label Name="CountryCodeLabel">Country code</Label>
+                                    <TextBox Name="CountryCodeText"  VerticalAlignment="Center"></TextBox>
+                                </DockPanel>
+                            </StackPanel>
                             <Button Name="SaveCountryCodeButton" Click="CountryCodeSave_ClickListener">Save</Button>
+                            <TextBlock Foreground="Red" Name="InfoLable" TextWrapping="Wrap"/>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
@@ -52,6 +52,10 @@ namespace Contoso.WPF.Puppet
             textAttachments = Settings.Default.TextErrorAttachments;
             TextAttachmentTextBox.Text = textAttachments;
             FileAttachmentLabel.Content = fileAttachments;
+            if (!string.IsNullOrEmpty(Settings.Default.CountryCode))
+            {
+                CountryCodeEnableCheckbox.IsChecked = true;
+            }
         }
 
         private void UpdateState()
@@ -121,14 +125,20 @@ namespace Contoso.WPF.Puppet
             }
             else
             {
-                CountryCodeText.Text = RegionInfo.CurrentRegion.TwoLetterISORegionName;
+                CountryCodeText.Text = string.IsNullOrEmpty(Settings.Default.CountryCode) 
+                    ? RegionInfo.CurrentRegion.TwoLetterISORegionName 
+                    : Settings.Default.CountryCode;
                 AppCenter.SetCountryCode(CountryCodeText.Text);
             }
+            Settings.Default.CountryCode = CountryCodeText.Text;
+            Settings.Default.Save();
             CountryCodePanel.IsEnabled = CountryCodeEnableCheckbox.IsChecked.Value;
         }
 
         private void CountryCodeSave_ClickListener(object sender, RoutedEventArgs e)
         {
+            Settings.Default.CountryCode = CountryCodeText.Text;
+            Settings.Default.Save();
             AppCenter.SetCountryCode(CountryCodeText.Text.Length > 0 ? CountryCodeText.Text : null);
         }
 

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
@@ -28,8 +28,6 @@ namespace Contoso.WPF.Puppet
 
         private string textAttachments;
 
-        private const string SaveCountryCodeLabelText = "Country code update. Please close the application completely and relaunch it.";
-
         private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions =
             new Dictionary<LogLevel, Action<string, string>>
             {
@@ -140,10 +138,9 @@ namespace Contoso.WPF.Puppet
 
         private void CountryCodeSave_ClickListener(object sender, RoutedEventArgs e)
         {
-            InfoLable.Text = SaveCountryCodeLabelText;
+            InfoLable.Visibility = Visibility.Visible;
             Settings.Default.CountryCode = CountryCodeText.Text;
             Settings.Default.Save();
-            AppCenter.SetCountryCode(CountryCodeText.Text.Length > 0 ? CountryCodeText.Text : null);
         }
 
         private void FileErrorAttachment_Click(object sender, RoutedEventArgs e)

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
@@ -141,6 +141,7 @@ namespace Contoso.WPF.Puppet
             InfoLable.Visibility = Visibility.Visible;
             Settings.Default.CountryCode = CountryCodeText.Text;
             Settings.Default.Save();
+            AppCenter.SetCountryCode(string.IsNullOrEmpty(Settings.Default.CountryCode) ? null : Settings.Default.CountryCode);
         }
 
         private void FileErrorAttachment_Click(object sender, RoutedEventArgs e)

--- a/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
+++ b/Apps/Contoso.WPF.Puppet/MainWindow.xaml.cs
@@ -28,6 +28,8 @@ namespace Contoso.WPF.Puppet
 
         private string textAttachments;
 
+        private const string SaveCountryCodeLabelText = "Country code update. Please close the application completely and relaunch it.";
+
         private static readonly IDictionary<LogLevel, Action<string, string>> LogFunctions =
             new Dictionary<LogLevel, Action<string, string>>
             {
@@ -120,23 +122,25 @@ namespace Contoso.WPF.Puppet
             }
             if (!CountryCodeEnableCheckbox.IsChecked.Value)
             {
-               CountryCodeText.Text = "";
-                AppCenter.SetCountryCode(null);
+                CountryCodeText.Text = "";
             }
             else
             {
-                CountryCodeText.Text = string.IsNullOrEmpty(Settings.Default.CountryCode) 
-                    ? RegionInfo.CurrentRegion.TwoLetterISORegionName 
-                    : Settings.Default.CountryCode;
-                AppCenter.SetCountryCode(CountryCodeText.Text);
+                if (string.IsNullOrEmpty(Settings.Default.CountryCode))
+                {
+                    CountryCodeText.Text = RegionInfo.CurrentRegion.TwoLetterISORegionName;
+                }
+                else
+                {
+                    CountryCodeText.Text = Settings.Default.CountryCode;
+                }
             }
-            Settings.Default.CountryCode = CountryCodeText.Text;
-            Settings.Default.Save();
             CountryCodePanel.IsEnabled = CountryCodeEnableCheckbox.IsChecked.Value;
         }
 
         private void CountryCodeSave_ClickListener(object sender, RoutedEventArgs e)
         {
+            InfoLable.Text = SaveCountryCodeLabelText;
             Settings.Default.CountryCode = CountryCodeText.Text;
             Settings.Default.Save();
             AppCenter.SetCountryCode(CountryCodeText.Text.Length > 0 ? CountryCodeText.Text : null);

--- a/Apps/Contoso.WPF.Puppet/Properties/Settings.Designer.cs
+++ b/Apps/Contoso.WPF.Puppet/Properties/Settings.Designer.cs
@@ -46,5 +46,17 @@ namespace Contoso.WPF.Puppet.Properties {
                 this["TextErrorAttachments"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CountryCode {
+            get {
+                return ((string)(this["CountryCode"]));
+            }
+            set {
+                this["CountryCode"] = value;
+            }
+        }
     }
 }

--- a/Apps/Contoso.WPF.Puppet/Properties/Settings.settings
+++ b/Apps/Contoso.WPF.Puppet/Properties/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="TextErrorAttachments" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="CountryCode" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

- The app should persist it and restore at app restart.
- If analytics enabled, disable/reenable to refresh session when updating in-app.

![image](https://user-images.githubusercontent.com/42138465/61785784-1a484180-ae15-11e9-82c0-33d8b6301b79.png)

![image](https://user-images.githubusercontent.com/42138465/61785814-26340380-ae15-11e9-8030-c4f2570a8b8c.png)

## Related PRs or issues

[AB#65192](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/65192)
