### PR TITLE
Fix flaky test

### DIFF
--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/AppCenterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/AppCenterTest.cs
@@ -7,19 +7,14 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop
 {
     public class AppCenterTest
     {
-        public AppCenterTest()
-        {
-            AppCenter.Instance = null;
-        }
-
         /// <summary>
         /// Verify configure with WindowsDesktop platform id
         /// </summary>
         [Fact]
         public void VerifyPlatformId()
         {
-            AppCenter.Configure("windowsdesktop=appsecret");
-            Assert.True(AppCenter.Configured);
+            var appClientId = AppCenter.GetSecretForPlatform("windowsdesktop=6a367cda-2c0a-4fb0-bedf-f110bf4e338b", "windowsdesktop");
+            Assert.Equal("6a367cda-2c0a-4fb0-bedf-f110bf4e338b", appClientId);
         }
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Another option would have been to move the method to ApplicationSettingsTest.cs, odd file access thing. The error was:

```
The process cannot access the file 'C:\Users\VssAdministrator\AppData\Local\Microsoft_Corporation\testhost_StrongName_ncwojqheyhc0dhynwiffp31oq4puy42y\AppCenter.config' because it is being used by another process.
```

It would not be practical to have all tests relying on AppCenter.config file access to be in the same test class though so for now using a unit test instead (but for some reason it works 100% of the time all the tests in ApplicationSettingsTest, including when moving the failing test there, it starts working reliably...).
We will have to figure out later when doing functional tests.

CI is broken half of the time because of this.