### PR TITLE
Also replace insecure Exception on Xamarin

### DIFF
--- a/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.puppet" android:versionCode="61" android:versionName="2.3.1-SNAPSHOT" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
 	<application android:label="SXPuppet" android:icon="@drawable/Icon" android:theme="@style/PuppetTheme">

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="62" android:versionName="2.3.1-SNAPSHOT" package="com.microsoft.appcenter.xamarin.forms.puppet">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
 	<application android:label="ACFPuppet">

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -87,7 +87,7 @@ namespace Contoso.Forms.Puppet
                 });
                 Crashes.GetLastSessionCrashReportAsync().ContinueWith(task =>
                 {
-                    AppCenterLog.Info(LogTag, "Crashes.LastSessionCrashReport.Exception=" + (task.Result?.Exception?.ToString() ?? task.Result?.StackTrace));
+                    AppCenterLog.Info(LogTag, "Crashes.LastSessionCrashReport.StackTrace=" + task.Result?.StackTrace);
                 });
             }
         }
@@ -108,62 +108,16 @@ namespace Contoso.Forms.Puppet
         static void SendingErrorReportHandler(object sender, SendingErrorReportEventArgs e)
         {
             AppCenterLog.Info(LogTag, "Sending error report");
-
-            var report = e.Report;
-
-            // Test some values
-            if (report.Exception != null)
-            {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
-            }
-            else if (report.AndroidDetails != null)
-            {
-                AppCenterLog.Info(LogTag, report.AndroidDetails.ThreadName);
-            }
         }
 
         static void SentErrorReportHandler(object sender, SentErrorReportEventArgs e)
         {
             AppCenterLog.Info(LogTag, "Sent error report");
-
-            var report = e.Report;
-
-            // Test some values
-            if (report.Exception != null)
-            {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
-            }
-            else
-            {
-                AppCenterLog.Info(LogTag, "No system exception was found");
-            }
-
-            if (report.AndroidDetails != null)
-            {
-                AppCenterLog.Info(LogTag, report.AndroidDetails.ThreadName);
-            }
         }
 
         static void FailedToSendErrorReportHandler(object sender, FailedToSendErrorReportEventArgs e)
         {
             AppCenterLog.Info(LogTag, "Failed to send error report");
-
-            var report = e.Report;
-
-            // Test some values
-            if (report.Exception != null)
-            {
-                AppCenterLog.Info(LogTag, report.Exception.ToString());
-            }
-            else if (report.AndroidDetails != null)
-            {
-                AppCenterLog.Info(LogTag, report.AndroidDetails.ThreadName);
-            }
-
-            if (e.Exception != null)
-            {
-                AppCenterLog.Info(LogTag, "There is an exception associated with the failure");
-            }
         }
 
         bool ShouldProcess(ErrorReport report)

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml
@@ -20,9 +20,6 @@
             <ViewCell Tapped="TestException">
                 <Button Text="Generate Test Exception" InputTransparent="true" Clicked="TestException" />
             </ViewCell>
-            <ViewCell Tapped="NonSerializableException">
-                <Button Text="Generate non serializable Exception" InputTransparent="true" Clicked="NonSerializableException" />
-            </ViewCell>
             <ViewCell Tapped="DivideByZero">
                 <Button Text="Divide 42 by 0" InputTransparent="true" Clicked="DivideByZero" />
             </ViewCell>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -143,11 +143,6 @@ namespace Contoso.Forms.Puppet
             HandleOrThrow(() => Crashes.GenerateTestCrash());
         }
 
-        void NonSerializableException(object sender, EventArgs e)
-        {
-            HandleOrThrow(() => throw new NonSerializableException());
-        }
-
         void DivideByZero(object sender, EventArgs e)
         {
             /* This is supposed to cause a crash, so we don't care that the variable 'x' is never used */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,7 @@
 
 ### App Center Crashes
 
-#### WPF/WinForms
-
-* **[Fix]** Remove insecure implementation of the raw `ErrorReport.Exception` property, now providing `string StackTrace` property as an alternative.
-
-#### UWP
-
-* **[Feature]** Add `StackTrace` property to the `ErrorReport` object.
+* **[Breaking change]** Remove insecure implementation of the raw `ErrorReport.Exception` property (now always returns `null` and marked as obsolete), and provide `string StackTrace` property as an alternative on Xamarin, UWP, WPF and WinForms.
 
 ## Version 2.3.0-preview
 

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/ErrorReport.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/ErrorReport.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AppCenter.Crashes
             byte[] exceptionBytes = AndroidExceptionDataManager.LoadWrapperExceptionData(Java.Util.UUID.FromString(Id));
             if (exceptionBytes != null)
             {
-                Exception = CrashesUtils.DeserializeException(exceptionBytes);
+                StackTrace = CrashesUtils.DeserializeException(exceptionBytes);
             }
         }
     }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared.Targets/CrashesUtils.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
 
 namespace Microsoft.AppCenter.Crashes
 {
@@ -11,38 +10,14 @@ namespace Microsoft.AppCenter.Crashes
     {
         internal static byte[] SerializeException(Exception exception)
         {
-            if (!exception.GetType().IsSerializable)
-            {
-                AppCenterLog.Warn(Crashes.LogTag, $"Cannot serialize {exception.GetType().FullName} exception for client side inspection. " +
-                                  "If you want to have access to the exception in the callbacks, please add a Serializable attribute " +
-                                  "and a deserialization constructor to the exception class.");
-                return null;
-            }
-            try
-            {
-                using (var memoryStream = new MemoryStream())
-                {
-                    var formatter = new BinaryFormatter();
-                    formatter.Serialize(memoryStream, exception);
-                    return memoryStream.ToArray();
-                }
-            }
-            catch (Exception e)
-            {
-                AppCenterLog.Warn(Crashes.LogTag, "Failed to serialize exception for client side inspection.", e);
-            }
-            return null;
+            return Encoding.UTF8.GetBytes(exception.ToString());
         }
 
-        internal static Exception DeserializeException(byte[] exceptionBytes)
+        internal static string DeserializeException(byte[] exceptionBytes)
         {
             try
             {
-                using (var memoryStream = new MemoryStream(exceptionBytes))
-                {
-                    var formatter = new BinaryFormatter();
-                    return formatter.Deserialize(memoryStream) as Exception;
-                }
+                return Encoding.UTF8.GetString(exceptionBytes);
             }
             catch (Exception e)
             {

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared/ErrorReport.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Shared/ErrorReport.cs
@@ -35,13 +35,14 @@ namespace Microsoft.AppCenter.Crashes
         public Device Device { get; }
 
         /// <summary>
-        /// Gets the C# Exception object that caused the crash. Available only on Xamarin.
+        /// Gets the C# Exception object that caused the crash.
         /// </summary>
         /// <value>The exception.</value>
+        [ObsoleteAttribute("This property is no longer set due to a security issue, use StackTrace as an alternative.")]
         public Exception Exception { get; }
 
         /// <summary>
-        /// Gets the C# exception stack trace captured at crash time. Available only on Windows.
+        /// Gets the C# exception stack trace captured at crash time.
         /// </summary>
         /// <value>The exception.</value>
         public string StackTrace { get; }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/ErrorReport.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/ErrorReport.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AppCenter.Crashes
             MSWrapperException wrapperException = MSWrapperExceptionManager.LoadWrapperExceptionWithUUID(msReport.IncidentIdentifier);
             if (wrapperException != null && wrapperException.ExceptionData != null && wrapperException.ExceptionData.Length > 0)
             {
-                Exception = CrashesUtils.DeserializeException(wrapperException.ExceptionData.ToArray());
+                StackTrace = CrashesUtils.DeserializeException(wrapperException.ExceptionData.ToArray());
             }
         }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix possible deserialization vulnerability on Xamarin, similar to the Windows one.

## Related PRs or issues

Follow up on [AB#63996](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/63996) / #1098 as it impacts Xamarin as well.
Though Xamarin is sandboxed application files (android & ios), Microsoft does not want to rely on that and just forbids this usage of BinaryFormatter.
