### PR TITLE
Unhandled exceptions: don't alter behavior of the app when adding our SDK

### DIFF
--- a/Apps/Contoso.WinForms.Demo.DotNetCore/Program.cs
+++ b/Apps/Contoso.WinForms.Demo.DotNetCore/Program.cs
@@ -17,6 +17,8 @@ namespace Contoso.WinForms.Demo.DotNetCore
         [STAThread]
         static void Main()
         {
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.Start("734be4f7-3607-489b-ae81-284d2eb908f8", typeof(Analytics), typeof(Crashes));
 

--- a/Apps/Contoso.WinForms.Demo/Program.cs
+++ b/Apps/Contoso.WinForms.Demo/Program.cs
@@ -17,6 +17,8 @@ namespace Contoso.WinForms.Demo
         [STAThread]
         static void Main()
         {
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.Start("734be4f7-3607-489b-ae81-284d2eb908f8", typeof(Analytics), typeof(Crashes));
 

--- a/Apps/Contoso.WinForms.Puppet.DotNetCore/Program.cs
+++ b/Apps/Contoso.WinForms.Puppet.DotNetCore/Program.cs
@@ -17,6 +17,8 @@ namespace Contoso.WinForms.Puppet.DotNetCore
         [STAThread]
         static void Main()
         {
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
             AppCenter.Start("7136db69-7f8d-4a14-90bd-12c9588ae0b9", typeof(Analytics), typeof(Crashes));

--- a/Apps/Contoso.WinForms.Puppet/Program.cs
+++ b/Apps/Contoso.WinForms.Puppet/Program.cs
@@ -17,6 +17,8 @@ namespace Contoso.WinForms.Puppet
         [STAThread]
         static void Main()
         {
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+
             AppCenter.LogLevel = LogLevel.Verbose;
             AppCenter.SetLogUrl("https://in-integration.dev.avalanch.es");
             AppCenter.Start("7136db69-7f8d-4a14-90bd-12c9588ae0b9", typeof(Analytics), typeof(Crashes));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### WinForms
 
-* **[Fix]** Don't prevent WinForms applications from crashing. If unhandled exceptions are handled by the application, they must now be reported using `Crashes.TrackError` to be displayed on AppCenter, see the public documentation for more details about this change.
+* **[Fix]** Don't prevent WinForms applications from crashing. If unhandled exceptions are handled by the application, they must now be reported using `Crashes.TrackError` to be displayed on AppCenter, see the [public documentation](https://docs.microsoft.com/en-us/appcenter/sdk/crashes/wpf-winforms) for more details about this change.
 
 ## Version 2.3.0-preview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@
 
 ### App Center
 
+#### WPF/WinForms
+
 * **[Fix]** Fix application version being reported for ClickOnce deployments.
 
 ### App Center Crashes
 
 * **[Breaking change]** Remove insecure implementation of the raw `ErrorReport.Exception` property (now always returns `null` and marked as obsolete), and provide `string StackTrace` property as an alternative on Xamarin, UWP, WPF and WinForms.
+
+#### WinForms
+
+* **[Fix]** Don't prevent WinForms applications from crashing. If unhandled exceptions are handled by the application, they must now be reported using `Crashes.TrackError` to be displayed on AppCenter, see the public documentation for more details about this change.
 
 ## Version 2.3.0-preview
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelper.cs
@@ -119,20 +119,10 @@ namespace Microsoft.AppCenter.Utils
         public ApplicationLifecycleHelper()
         {
             Enabled = true;
-
-            // Add the event handler for handling UI thread exceptions to the event.
-            Application.ThreadException += (sender, args) => InvokeUnhandledException(sender, args.Exception);
-
-            // Add the event handler for handling non-UI thread exceptions to the event. 
-            AppDomain.CurrentDomain.UnhandledException += (sender, args) => InvokeUnhandledException(sender, args.ExceptionObject as Exception);
-        }
-
-        private void InvokeUnhandledException(object sender, Exception exception)
-        {
-            if (exception != null)
+            AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
             {
-                UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs(exception));
-            }
+                UnhandledExceptionOccurred?.Invoke(sender, new UnhandledExceptionOccurredEventArgs((Exception)eventArgs.ExceptionObject));
+            };
         }
 
         private void InvokeResuming()


### PR DESCRIPTION
This reverts commit 8c061baaa18f49869e570f7cc91be4f4ce37e86c, reversing
changes made to c4cea8c0f2d0c7c74ae04e6500862388189a05dc.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

On WinForms the fact that the app crashes or does not crash is controlled by the developer of the application.
Defining ThreadException handler actually alters the behavior of the application and still is not enough to let application crash anyway (that would need to also set unhandled exception mode).

We are going to avoid altering the application behavior when integrating our SDK by reverting the previous change on handlers and document instead how to let app crash or how to handle and track exceptions using TrackException.

## Related PRs or issues

[AB#67780](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/67780)
#1103
#1104
