### PR TITLE
Send attachments in trackError

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -60,7 +60,7 @@ namespace Contoso.Forms.Demo
                 // Set callbacks
                 Crashes.ShouldProcessErrorReport = ShouldProcess;
                 Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
-                Crashes.GetErrorAttachments = GetErrorAttachments;
+                Crashes.GetErrorAttachments = GetErrorAttachmentsCallback;
                 Distribute.ReleaseAvailable = OnReleaseAvailable;
 
                 // Event handlers
@@ -176,7 +176,12 @@ namespace Contoso.Forms.Demo
             return true;
         }
 
-        static IEnumerable<ErrorAttachmentLog> GetErrorAttachments(ErrorReport report)
+        static IEnumerable<ErrorAttachmentLog> GetErrorAttachmentsCallback(ErrorReport report)
+        {
+            return GetErrorAttachments();
+        }
+
+        public static IEnumerable<ErrorAttachmentLog> GetErrorAttachments()
         {
             var attachments = new List<ErrorAttachmentLog>();
             if (Current.Properties.TryGetValue(CrashesContentPage.TextAttachmentKey, out var textAttachment) &&

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -243,7 +243,7 @@ namespace Contoso.Forms.Demo
             Properties.Clear();
             RefreshPropCount();
             // TODO: uncomment this when API will be added.
-            Crashes.TrackError(e, properties /*, App.GetErrorAttachments() */);
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
 
         }
 

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -242,7 +242,9 @@ namespace Contoso.Forms.Demo
             }
             Properties.Clear();
             RefreshPropCount();
-            Crashes.TrackError(e, properties);
+            // TODO: uncomment this when API will be added.
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments() */);
+
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -60,7 +60,7 @@ namespace Contoso.Forms.Puppet
                 // Set callbacks
                 Crashes.ShouldProcessErrorReport = ShouldProcess;
                 Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
-                Crashes.GetErrorAttachments = GetErrorAttachments;
+                Crashes.GetErrorAttachments = GetErrorAttachmentsCallback;
                 Distribute.ReleaseAvailable = OnReleaseAvailable;
 
                 // Event handlers
@@ -182,7 +182,12 @@ namespace Contoso.Forms.Puppet
             return true;
         }
 
-        static IEnumerable<ErrorAttachmentLog> GetErrorAttachments(ErrorReport report)
+        static IEnumerable<ErrorAttachmentLog> GetErrorAttachmentsCallback(ErrorReport report)
+        {
+            return GetErrorAttachments();
+        }
+
+        public static IEnumerable<ErrorAttachmentLog> GetErrorAttachments()
         {
             var attachments = new List<ErrorAttachmentLog>();
             if (Current.Properties.TryGetValue(CrashesContentPage.TextAttachmentKey, out var textAttachment) &&

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -243,7 +243,7 @@ namespace Contoso.Forms.Puppet
             RefreshPropCount();
 
             // TODO: uncomment this when API will be added.
-            Crashes.TrackError(e, properties /*, App.GetErrorAttachments() */);
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -241,7 +241,9 @@ namespace Contoso.Forms.Puppet
             }
             Properties.Clear();
             RefreshPropCount();
-            Crashes.TrackError(e, properties);
+
+            // TODO: uncomment this when API will be added.
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments() */);
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)


### PR DESCRIPTION
Modify the Xamarin.Forms test apps to send attachments even when "handle errors" toggle is on. Also ensure that the attachments functionality remains enabled in this case.

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Modify the Xamarin.Forms test apps to send attachments even when "handle errors" toggle is on. Also ensure that the attachments functionality remains enabled in this case.

## Related PRs or issues

[AB#71075](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/71075)