### PR TITLE
Update xamarin.android and xamarin.ios bindings for handled error attachment API

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/App.xaml.cs
@@ -60,7 +60,7 @@ namespace Contoso.Forms.Demo
                 // Set callbacks
                 Crashes.ShouldProcessErrorReport = ShouldProcess;
                 Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
-                Crashes.GetErrorAttachments = GetErrorAttachments;
+                Crashes.GetErrorAttachments = GetErrorAttachmentsCallback;
                 Distribute.ReleaseAvailable = OnReleaseAvailable;
 
                 // Event handlers
@@ -176,7 +176,12 @@ namespace Contoso.Forms.Demo
             return true;
         }
 
-        static IEnumerable<ErrorAttachmentLog> GetErrorAttachments(ErrorReport report)
+        static IEnumerable<ErrorAttachmentLog> GetErrorAttachmentsCallback(ErrorReport report)
+        {
+            return GetErrorAttachments();
+        }
+
+        public static IEnumerable<ErrorAttachmentLog> GetErrorAttachments()
         {
             var attachments = new List<ErrorAttachmentLog>();
             if (Current.Properties.TryGetValue(CrashesContentPage.TextAttachmentKey, out var textAttachment) &&

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -242,7 +242,9 @@ namespace Contoso.Forms.Demo
             }
             Properties.Clear();
             RefreshPropCount();
-            Crashes.TrackError(e, properties, App.GetErrorAttachments().ToArray());
+
+            // TODO: uncomment the App.GetErrorAttachments().ToArray() when the SDK is released.
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -242,9 +242,7 @@ namespace Contoso.Forms.Demo
             }
             Properties.Clear();
             RefreshPropCount();
-            // TODO: uncomment this when API will be added.
-            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
-
+            Crashes.TrackError(e, properties, App.GetErrorAttachments().ToArray();
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -242,7 +242,7 @@ namespace Contoso.Forms.Demo
             }
             Properties.Clear();
             RefreshPropCount();
-            Crashes.TrackError(e, properties, App.GetErrorAttachments().ToArray();
+            Crashes.TrackError(e, properties, App.GetErrorAttachments().ToArray());
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/CrashesContentPage.xaml.cs
@@ -242,7 +242,9 @@ namespace Contoso.Forms.Demo
             }
             Properties.Clear();
             RefreshPropCount();
-            Crashes.TrackError(e, properties);
+            // TODO: uncomment this when API will be added.
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
+
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/App.xaml.cs
@@ -60,7 +60,7 @@ namespace Contoso.Forms.Puppet
                 // Set callbacks
                 Crashes.ShouldProcessErrorReport = ShouldProcess;
                 Crashes.ShouldAwaitUserConfirmation = ConfirmationHandler;
-                Crashes.GetErrorAttachments = GetErrorAttachments;
+                Crashes.GetErrorAttachments = GetErrorAttachmentsCallback;
                 Distribute.ReleaseAvailable = OnReleaseAvailable;
 
                 // Event handlers
@@ -182,7 +182,12 @@ namespace Contoso.Forms.Puppet
             return true;
         }
 
-        static IEnumerable<ErrorAttachmentLog> GetErrorAttachments(ErrorReport report)
+        static IEnumerable<ErrorAttachmentLog> GetErrorAttachmentsCallback(ErrorReport report)
+        {
+            return GetErrorAttachments();
+        }
+
+        public static IEnumerable<ErrorAttachmentLog> GetErrorAttachments()
         {
             var attachments = new List<ErrorAttachmentLog>();
             if (Current.Properties.TryGetValue(CrashesContentPage.TextAttachmentKey, out var textAttachment) &&

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -241,9 +241,7 @@ namespace Contoso.Forms.Puppet
             }
             Properties.Clear();
             RefreshPropCount();
-
-            // TODO: uncomment this when API will be added.
-            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
+            Crashes.TrackError(e, properties, App.GetErrorAttachments().ToArray());
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/CrashesContentPage.xaml.cs
@@ -241,7 +241,9 @@ namespace Contoso.Forms.Puppet
             }
             Properties.Clear();
             RefreshPropCount();
-            Crashes.TrackError(e, properties);
+
+            // TODO: uncomment this when API will be added.
+            Crashes.TrackError(e, properties /*, App.GetErrorAttachments().ToArray() */);
         }
 
         void ClearCrashUserConfirmation(object sender, EventArgs e)

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
@@ -94,7 +94,15 @@ namespace Microsoft.AppCenter.Crashes
                 attachmentArray = new ArrayList();
                 foreach (var attachment in attachments)
                 {
-                    attachmentArray.Add(attachment.internalAttachment);
+                    if (attachment?.internalAttachment != null)
+                    {
+
+                        attachmentArray.Add(attachment.internalAttachment);
+                    }
+                    else
+                    {
+                        AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog in Crashes.TrackError.");
+                    }
                 }
             }
             WrapperSdkExceptionManager.TrackException(GenerateModelException(exception, false), properties, attachmentArray);

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
@@ -88,7 +88,15 @@ namespace Microsoft.AppCenter.Crashes
 
         static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, ErrorAttachmentLog[] attachments)
         {
-            ArrayList attachmentArray = attachments != null ? new ArrayList(attachments) : null;
+            ArrayList attachmentArray = null;
+            if (attachments != null)
+            {
+                attachmentArray = new ArrayList();
+                foreach (var attachment in attachments)
+                {
+                    attachmentArray.Add(attachment.internalAttachment);
+                }
+            }
             WrapperSdkExceptionManager.TrackException(GenerateModelException(exception, false), properties, attachmentArray);
         }
 

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
@@ -86,9 +86,9 @@ namespace Microsoft.AppCenter.Crashes
             return Task.Run(() => (bool)future.Get());
         }
 
-        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties)
+        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, params ErrorAttachmentLog[] attachments)
         {
-            WrapperSdkExceptionManager.TrackException(GenerateModelException(exception, false), properties);
+            WrapperSdkExceptionManager.TrackException(GenerateModelException(exception, false), properties, new ArrayList(attachments));
         }
 
         // Empty model stack frame used for comparison to optimize JSON payload.

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
@@ -86,9 +86,10 @@ namespace Microsoft.AppCenter.Crashes
             return Task.Run(() => (bool)future.Get());
         }
 
-        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, params ErrorAttachmentLog[] attachments)
+        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, ErrorAttachmentLog[] attachments)
         {
-            WrapperSdkExceptionManager.TrackException(GenerateModelException(exception, false), properties, new ArrayList(attachments));
+            ArrayList attachmentArray = attachments != null ? new ArrayList(attachments) : null;
+            WrapperSdkExceptionManager.TrackException(GenerateModelException(exception, false), properties, attachmentArray);
         }
 
         // Empty model stack frame used for comparison to optimize JSON payload.

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Android/Crashes.cs
@@ -96,7 +96,6 @@ namespace Microsoft.AppCenter.Crashes
                 {
                     if (attachment?.internalAttachment != null)
                     {
-
                         attachmentArray.Add(attachment.internalAttachment);
                     }
                     else

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/ApiDefinition.cs
@@ -111,15 +111,10 @@ namespace Microsoft.AppCenter.Crashes.iOS.Bindings
         [Export("disableMachExceptionHandler")]
         void DisableMachExceptionHandler();
 
-        //+(void)trackModelException:(MSException *)exception;
+        //+(void)trackModelException:(MSException *)exception withProperties:(NSDictionary *)properties withAttachments:(nullable NSArray<MSErrorAttachmentLog *> *)attachments;
         [Static]
-        [Export("trackModelException:")]
-        void TrackModelException(MSException exception);
-
-        //+(void)trackModelException:(MSException *)exception withProperties:(NSDictionary *)properties;
-        [Static]
-        [Export("trackModelException:withProperties:")]
-        void TrackModelException(MSException exception, NSDictionary properties);
+        [Export("trackModelException:withProperties:withAttachments:")]
+        void TrackModelException(MSException exception, NSDictionary properties, NSArray attachments);
     }
 
     // @protocol MSCrashesDelegate <NSObject>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -73,14 +73,24 @@ namespace Microsoft.AppCenter.Crashes
             MSCrashes.NotifyWithUserConfirmation(iosUserConfirmation);
         }
 
-        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties)
+        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, params ErrorAttachmentLog[] attachments)
         {
-            if (properties != null)
+            var attachmentArray = new NSMutableArray();
+            if (attachments != null)
             {
-                MSCrashes.TrackModelException(GenerateiOSException(exception, false), StringDictToNSDict(properties));
-                return;
+                foreach (var attachment in attachments)
+                {
+                    if (attachment != null)
+                    {
+                        attachmentArray.Add(attachment.internalAttachment);
+                    }
+                    else
+                    {
+                        AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog in Crashes.TrackError.");
+                    }
+                }
             }
-            MSCrashes.TrackModelException(GenerateiOSException(exception, false));
+            MSCrashes.TrackModelException(GenerateiOSException(exception, false), StringDictToNSDict(properties), attachmentArray);
         }
 
         /// <summary>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AppCenter.Crashes
                 attachmentArray = new NSMutableArray();
                 foreach (var attachment in attachments)
                 {
-                    if (attachment.internalAttachment != null)
+                    if (attachment?.internalAttachment != null)
                     {
                         attachmentArray.Add(attachment.internalAttachment);
                     }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -73,11 +73,13 @@ namespace Microsoft.AppCenter.Crashes
             MSCrashes.NotifyWithUserConfirmation(iosUserConfirmation);
         }
 
-        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, params ErrorAttachmentLog[] attachments)
+        static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, ErrorAttachmentLog[] attachments)
         {
-            var attachmentArray = new NSMutableArray();
+            NSDictionary propertyDictionary = properties != null ? StringDictToNSDict(properties) : null;
+            NSMutableArray attachmentArray = null;
             if (attachments != null)
             {
+                attachmentArray = new NSMutableArray();
                 foreach (var attachment in attachments)
                 {
                     if (attachment != null)
@@ -90,7 +92,7 @@ namespace Microsoft.AppCenter.Crashes
                     }
                 }
             }
-            MSCrashes.TrackModelException(GenerateiOSException(exception, false), StringDictToNSDict(properties), attachmentArray);
+            MSCrashes.TrackModelException(GenerateiOSException(exception, false), propertyDictionary, attachmentArray);
         }
 
         /// <summary>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AppCenter.Crashes
                 attachmentArray = new NSMutableArray();
                 foreach (var attachment in attachments)
                 {
-                    if (attachment != null)
+                    if (attachment.internalAttachment != null)
                     {
                         attachmentArray.Add(attachment.internalAttachment);
                     }

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -75,21 +75,17 @@ namespace Microsoft.AppCenter.Crashes
 
         static void PlatformTrackError(Exception exception, IDictionary<string, string> properties, ErrorAttachmentLog[] attachments)
         {
-            NSDictionary propertyDictionary = properties != null ? StringDictToNSDict(properties) : null;
-            NSMutableArray attachmentArray = null;
-            if (attachments != null)
+            NSDictionary propertyDictionary = properties != null ? StringDictToNSDict(properties) : new NSDictionary();
+            NSMutableArray attachmentArray = new NSMutableArray();
+            foreach (var attachment in attachments)
             {
-                attachmentArray = new NSMutableArray();
-                foreach (var attachment in attachments)
+                if (attachment?.internalAttachment != null)
                 {
-                    if (attachment?.internalAttachment != null)
-                    {
-                        attachmentArray.Add(attachment.internalAttachment);
-                    }
-                    else
-                    {
-                        AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog in Crashes.TrackError.");
-                    }
+                    attachmentArray.Add(attachment.internalAttachment);
+                }
+                else
+                {
+                    AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog in Crashes.TrackError.");
                 }
             }
             MSCrashes.TrackModelException(GenerateiOSException(exception, false), propertyDictionary, attachmentArray);

--- a/scripts/configuration/ac-build-config.xml
+++ b/scripts/configuration/ac-build-config.xml
@@ -2,8 +2,8 @@
 <config>
     <sdkInfo>
         <sdkVersion>2.4.1-SNAPSHOT</sdkVersion>
-        <iosVersion>2.4.0</iosVersion>
-        <androidVersion>2.4.0-4+08074e47b</androidVersion>
+        <iosVersion>2.5.1-1+b181dfabecabc6908810d7bb0264724ae72f0ba7</iosVersion>
+        <androidVersion>2.4.1-4+b0456112e</androidVersion>
     </sdkInfo>
     <group id="ios" folder="iOSAssemblies" buildGroup="mac">
         <assembly path="SDK/AppCenter/Microsoft.AppCenter.iOS/bin/Release/Microsoft.AppCenter.dll"/>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Update xamarin.android and xamarin.ios bindings for handled error attachment API

## Related PRs or issues

[AB#71071](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/71071)

#1170 depends on this PR to pass Xamarin CI.
