### PR TITLE
UserId saved after change

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/ModulePages/AppCenterContentPage.xaml.cs
@@ -64,12 +64,13 @@ namespace Contoso.Forms.Demo
             {
                 UserIdEntry.Text = id;
             }
-            UserIdEntry.Unfocused += (sender, args) =>
+            UserIdEntry.Unfocused += async (sender, args) =>
             {
                 var inputText = UserIdEntry.Text;
                 var text = string.IsNullOrEmpty(inputText) ? null : inputText;
                 AppCenter.SetUserId(text);
                 Application.Current.Properties[Constants.UserId] = text;
+                await Application.Current.SavePropertiesAsync();
             };
         }
 

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet/ModulePages/AppCenterContentPage.xaml.cs
@@ -81,12 +81,13 @@ namespace Contoso.Forms.Puppet
             {
                 UserIdEntry.Text = id;
             }
-            UserIdEntry.Unfocused += (sender, args) =>
+            UserIdEntry.Unfocused += async (sender, args) =>
             {
                 var inputText = UserIdEntry.Text;
                 var text = string.IsNullOrEmpty(inputText) ? null : inputText;
                 AppCenter.SetUserId(text);
                 Application.Current.Properties[Constants.UserId] = text;
+                await Application.Current.SavePropertiesAsync();
             };
         }
 


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Application properties were not saved after 'UserId' was changed. When application started after the crash then old properties restored. The application properties saving was added to the 'UserId' change handler.

## Misc

[AB#72493](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72493)
