### PR TITLE
Replace string split by regex to avoid xamarin android issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Android
 
-* **[Fix]** Fix `MissingMethodException` that could occur with some build configurations (bug introduced in version 2.5.0).
+* **[Fix]** Fix `MissingMethodException` that could occur with some build configurations (a bug introduced in version `2.5.0`).
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 2.6.3 （Under development）
 
+### AppCenter
+
+#### Android
+
+* **[Fix]** Fix `MissingMethodException` that could occur with some build configurations (bug introduced in version 2.5.0).
+
 ___
 
 ## Version 2.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Android
 
-* **[Fix]** Fix `MissingMethodException` that could occur with some build configurations (a bug introduced in version `2.5.0`).
+* **[Fix]** Fix `MissingMethodException` of `String.Split()` with some build configurations (a bug introduced in version `2.5.0`).
 
 ___
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Android/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Android/AppCenter.cs
@@ -161,7 +161,11 @@ namespace Microsoft.AppCenter
             if (monoAssemblyVersionAttibutes?.Length > 0)
             {
                 xamarinAndroidVersion = monoAssemblyVersionAttibutes[0].InformationalVersion;
-                xamarinAndroidVersion = xamarinAndroidVersion?.Split(';')[0];
+                var indexOfVersion = xamarinAndroidVersion?.IndexOf(';') ?? -1;
+                if (indexOfVersion >= 0)
+                {
+                    xamarinAndroidVersion = xamarinAndroidVersion?.Substring(0, indexOfVersion + 1);
+                }
             }
             var wrapperSdk = new AndroidWrapperSdk
             {

--- a/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AppCenter
             // Iterate over matching patterns.
             var secretsDictionary = new Dictionary<string, string>();
             var matches = _secretsRegex.Matches(secrets);
-            foreach (Match match in matches)
+            foreach (var match in matches)
             {
                 secretsDictionary[match.Groups[1].Value] = match.Groups[2].Value;
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AppCenter
             // Iterate over matching patterns.
             var secretsDictionary = new Dictionary<string, string>();
             var matches = _secretsRegex.Matches(secrets);
-            foreach (var match in matches)
+            foreach (Match match in matches)
             {
                 secretsDictionary[match.Groups[1].Value] = match.Groups[2].Value;
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AppCenter
         const string TargetKeyName = "target";
         const string TargetKeyNameUpper = "Target";
         const string AppSecretKeyName = "appsecret";
-        const string SecretsPattern = @"(?:([^;=]+)=([^;=]+));?";
+        const string SecretsPattern = @"([^;=]+)=([^;=]+);?";
 
 #if NETSTANDARD
         static readonly Regex _secretsRegex = new Regex(SecretsPattern);

--- a/Tests/Microsoft.AppCenter.Test.Windows/AppCenterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/AppCenterTest.cs
@@ -658,7 +658,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        /// Verify empty pairs are ignored
+        /// Verify empty pairs are ignored.
         /// </summary>
         [TestMethod]
         public void ParseValidSecretSurroundedWithInvalidPairs()
@@ -671,7 +671,7 @@ namespace Microsoft.AppCenter.Test
         }
 
         /// <summary>
-        /// Verify last value is used on duplicate key
+        /// Verify last value is used on duplicate key.
         /// </summary>
         [TestMethod]
         public void ParseSecretUsesLastValueOnDuplicateKey()

--- a/Tests/Microsoft.AppCenter.Test.Windows/AppCenterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/AppCenterTest.cs
@@ -546,7 +546,7 @@ namespace Microsoft.AppCenter.Test
             var targetToken = Guid.NewGuid().ToString();
             var platformId = "ios";
             var secrets = $"{platformId}={appSecret};{platformId}Target={targetToken}";
-            var parsedSecret = AppCenter.GetSecretAndTargetForPlatform(secrets, invalidePlatformIdentifier);
+            AppCenter.GetSecretAndTargetForPlatform(secrets, invalidePlatformIdentifier);
         }
 
         /// <summary>
@@ -560,7 +560,7 @@ namespace Microsoft.AppCenter.Test
             var targetToken = string.Empty;
             var platformId = "ios";
             var secrets = $"{platformId}={appSecret};{platformId}Target={targetToken}";
-            var parsedSecret = AppCenter.GetSecretAndTargetForPlatform(secrets, platformId);
+            AppCenter.GetSecretAndTargetForPlatform(secrets, platformId);
         }
 
         /// <summary>
@@ -614,7 +614,7 @@ namespace Microsoft.AppCenter.Test
         {
             var appSecret = Guid.NewGuid().ToString();
             var platformId = "uwp";
-            var secrets = $"{platformId}={appSecret}; ios=anotherstring";
+            var secrets = $"{platformId}={appSecret};ios=anotherstring";
             var parsedSecret = AppCenter.GetSecretAndTargetForPlatform(secrets, platformId);
             Assert.AreEqual(appSecret, parsedSecret);
         }
@@ -655,6 +655,26 @@ namespace Microsoft.AppCenter.Test
             AppCenter.Configure(secrets);
 
             Assert.IsFalse(AppCenter.Configured);
+        }
+
+        [TestMethod]
+        public void ParseValidSecretSurroundedWithInvalidPairs()
+        {
+            var appSecret = Guid.NewGuid().ToString();
+            var platformId = "uwp";
+            var secrets = $"=;{platformId}={appSecret};=";
+            var parsedSecret = AppCenter.GetSecretAndTargetForPlatform(secrets, platformId);
+            Assert.AreEqual(appSecret, parsedSecret);
+        }
+
+        [TestMethod]
+        public void ParseSecretUsesLastValueOnDuplicateKey()
+        {
+            var appSecret = Guid.NewGuid().ToString();
+            var platformId = "uwp";
+            var secrets = $"{platformId}={Guid.NewGuid()};{platformId}={appSecret}";
+            var parsedSecret = AppCenter.GetSecretAndTargetForPlatform(secrets, platformId);
+            Assert.AreEqual(appSecret, parsedSecret);
         }
 
         /// <summary>

--- a/Tests/Microsoft.AppCenter.Test.Windows/AppCenterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/AppCenterTest.cs
@@ -657,6 +657,9 @@ namespace Microsoft.AppCenter.Test
             Assert.IsFalse(AppCenter.Configured);
         }
 
+        /// <summary>
+        /// Verify empty pairs are ignored
+        /// </summary>
         [TestMethod]
         public void ParseValidSecretSurroundedWithInvalidPairs()
         {
@@ -667,6 +670,9 @@ namespace Microsoft.AppCenter.Test
             Assert.AreEqual(appSecret, parsedSecret);
         }
 
+        /// <summary>
+        /// Verify last value is used on duplicate key
+        /// </summary>
         [TestMethod]
         public void ParseSecretUsesLastValueOnDuplicateKey()
         {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Try to avoid missing method exception on xamarin android with string split

## Related PRs or issues

[AB#73940](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/73940)
