### PR TITLE
Fix sending remaining pending logs after sending 3 concurrent HTTP requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### AppCenter
 
+#### UWP/WPF/WinForms
+
+* **[Fix]** Fix sending remaining pending logs after sending 3 concurrent HTTP requests.
+
 #### Android
 
 * **[Fix]** Fix `MissingMethodException` of `String.Split()` with some build configurations (a bug introduced in version `2.5.0`).

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -505,6 +505,7 @@ namespace Microsoft.AppCenter.Channel
             {
                 AppCenterLog.Warn(AppCenterLog.LogTag, $"Could not delete logs for batch {batchId}", e);
             }
+            CheckPendingLogs(state);
         }
 
         private void HandleSendingFailure(State state, string batchId, Exception exception)


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix sending remaining pending logs after sending 3 concurrent HTTP requests.

## Related PRs or issues

[AB#73904](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/73904)