### PR TITLE
allow status codes between 200 and 299 for ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 #### UWP/WPF/WinForms
 
 * **[Fix]** Fix sending remaining pending logs after sending 3 concurrent HTTP requests.
-* **[Fix]** Fix only accepting 200 HTTP success code instead of 200-299 range.
+* **[Fix]** The SDK was considering 201-299 status code as HTTP errors and is now fixed to accept all 2XX codes as successful.
 
 #### Android
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### UWP/WPF/WinForms
 
 * **[Fix]** Fix sending remaining pending logs after sending 3 concurrent HTTP requests.
+* **[Fix]** Fix only accepting 200 HTTP success code instead of 200-299 range.
 
 #### Android
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AppCenter.Ingestion.Http
                 }
                 var logMessage = $"HTTP response status={(int)response.StatusCode} ({response.StatusCode}) payload={logPayload}";
                 AppCenterLog.Verbose(AppCenterLog.LogTag, logMessage);
-                if (response.StatusCode != HttpStatusCode.OK)
+                if ((int)response.StatusCode < 200 || (int)response.StatusCode >= 300)
                 {
                     throw new HttpIngestionException(logMessage)
                     {

--- a/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpIngestionTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpIngestionTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AppCenter.Test.Windows.Ingestion.Http
         protected IList<Log> Logs => new List<Log>();
 
         /// <summary>
-        /// Helper for setup responce.
+        /// Helper for setup response.
         /// </summary>
         protected ISetup<IHttpNetworkAdapter, Task<string>> SetupAdapterSendResponse(params HttpStatusCode[] statusCodes)
         {
@@ -37,7 +37,7 @@ namespace Microsoft.AppCenter.Test.Windows.Ingestion.Http
             setup.Returns(() =>
             {
                 var statusCode = statusCodes[index < statusCodes.Length ? index++ : statusCodes.Length - 1];
-                return statusCode == HttpStatusCode.OK
+                return ((int)statusCode >= 200 && (int)statusCode < 300)
                     ? TaskExtension.GetCompletedTask("")
                     : TaskExtension.GetFaultedTask<string>(new HttpIngestionException("")
                     {

--- a/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/IngestionHttpTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/IngestionHttpTest.cs
@@ -38,12 +38,38 @@ namespace Microsoft.AppCenter.Test.Windows.Ingestion.Http
         }
 
         /// <summary>
-        /// Verify that ingestion throw exception on error response.
+        /// Verify that ingestion call http adapter and not fails on 2xx.
+        /// </summary>
+        [TestMethod]
+        public async Task HttpIngestionStatusCodePartialContent()
+        {
+            SetupAdapterSendResponse(HttpStatusCode.PartialContent);
+            var call = _httpIngestion.Call(AppSecret, InstallId, Logs);
+            await call.ToTask();
+            VerifyAdapterSend(Times.Once());
+
+            // No throw any exception
+        }
+
+        /// <summary>
+        /// Verify that ingestion throw exception on error response >= 300.
         /// </summary>
         [TestMethod]
         public async Task HttpIngestionStatusCodeError()
         {
             SetupAdapterSendResponse(HttpStatusCode.NotFound);
+            var call = _httpIngestion.Call(AppSecret, InstallId, Logs);
+            await Assert.ThrowsExceptionAsync<HttpIngestionException>(() => call.ToTask());
+            VerifyAdapterSend(Times.Once());
+        }
+
+        /// <summary>
+        /// Verify that ingestion throw exception on error response < 200.
+        /// </summary>
+        [TestMethod]
+        public async Task HttpIngestionStatusCodeErrorBelow200()
+        {
+            SetupAdapterSendResponse(HttpStatusCode.SwitchingProtocols);
             var call = _httpIngestion.Call(AppSecret, InstallId, Logs);
             await Assert.ThrowsExceptionAsync<HttpIngestionException>(() => call.ToTask());
             VerifyAdapterSend(Times.Once());


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

We want to be able to return success codes between 200-299

## Related PRs or issues

[AB#74325](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74325)

## Misc

The added unit tests are kind of dumb right now because we don't have dependency injection yet. There isn't a way to test the real SendAsync function until we've implemented functional testing on Windows.
