### PR TITLE
Fix ARM64 processor architecture reporting

### DIFF
--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Utils/ProcessInformation.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Utils/ProcessInformation.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using Windows.ApplicationModel;
+using System.Runtime.InteropServices;
 using Windows.System.Diagnostics;
 
 namespace Microsoft.AppCenter.Crashes.Utils
@@ -19,6 +19,10 @@ namespace Microsoft.AppCenter.Crashes.Utils
 
         public string ParentProcessName => ProcessDiagnosticInfo.GetForCurrentProcess().Parent?.ExecutableFileName;
 
-        public string ProcessArchitecture => Package.Current.Id.Architecture.ToString();
+        /// <remarks>
+        /// ARM64 was added to ProcessorArchitecture enum (that can be received by Package.Current.Id.Architecture call) only in SDK version 18362, 
+        /// so casting to string is incorrect on lower versions.
+        /// </remarks>
+        public string ProcessArchitecture => RuntimeInformation.ProcessArchitecture.ToString();
     }
 }


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

ARM64 was added to [ProcessorArchitecture](https://docs.microsoft.com/en-us/uwp/api/windows.system.processorarchitecture) enum (that can be received by `Package.Current.Id.Architecture` call) only in SDK version 18362, so casting to string is incorrect on lower versions.

## Related PRs or issues

[AB#74919](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74919)
https://github.com/microsoft/appcenter-sdk-dotnet/pull/1278#pullrequestreview-339631754

