### PR TITLE
Some tests are failing locally

### DIFF
--- a/Tests/Microsoft.AppCenter.Test.UWP/Utils/DeviceInformationHelperTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.UWP/Utils/DeviceInformationHelperTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AppCenter.Test.UWP.Utils
         public void VerifyDeviceOemName()
         {
             var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
-            Assert.AreNotEqual(device.OemName.ToLower(), AbstractDeviceInformationHelper.DefaultSystemManufacturer);
+            Assert.AreNotEqual(device.OemName, AbstractDeviceInformationHelper.DefaultSystemManufacturer);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.AppCenter.Test.UWP.Utils
         public void VerifyDeviceModel()
         {
             var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
-            Assert.AreNotEqual(device.Model.ToLower(), AbstractDeviceInformationHelper.DefaultSystemProductName);
+            Assert.AreNotEqual(device.Model, AbstractDeviceInformationHelper.DefaultSystemProductName);
         }
 
         /// <summary>

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/DeviceInformationHelperTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/DeviceInformationHelperTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
         public void VerifyDeviceOemName()
         {
             var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
-            Assert.NotEqual(device.OemName.ToLower(), AbstractDeviceInformationHelper.DefaultSystemManufacturer);
+            Assert.NotEqual(device.OemName, AbstractDeviceInformationHelper.DefaultSystemManufacturer);
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
         public void VerifyDeviceModel()
         {
             var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
-            Assert.NotEqual(device.Model.ToLower(), AbstractDeviceInformationHelper.DefaultSystemProductName);
+            Assert.NotEqual(device.Model, AbstractDeviceInformationHelper.DefaultSystemProductName);
         }
     }
 }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

In test class `DeviceInformationHelperTest` for `WindowsDesktop`, `UWP` and `WindowsDesktop.Core failure the tests methods `VerifyDeviceOemName` and `VerifyDeviceModel`.

Message: 
System.NullReferenceException : Object reference not set to an instance of an object.

## Related PRs or issues

[AB#74650](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/74650)
