### PR TITLE
Fix httpNetworkAdapter CancellationTokenSource creation

### DIFF
--- a/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
-            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
-            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
+            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET", delayTimeInSeconds: 5);
+            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService", delayTimeInSeconds: 5);
 
             // Start AppCenter.
             AppCenter.UnsetInstance();
@@ -55,8 +55,7 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             AppCenter.Start(Config.ResolveAppSecret(), typeof(Distribute));
 
             // Wait for "startService" log to be sent.
-            Task.WaitAny(startServiceTask, Task.Delay(5000));
-
+            await startServiceTask;
             DistributeEvent?.Invoke(this, DistributeTestType.OnResumeActivity);
 
             // Wait when Distribute will start.
@@ -83,8 +82,8 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
-            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
-            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
+            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET", delayTimeInSeconds: 5);
+            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService", delayTimeInSeconds: 5);
 
             // Start AppCenter.
             AppCenter.UnsetInstance();
@@ -93,8 +92,7 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             AppCenter.Start(Config.ResolveAppSecret(), typeof(Distribute));
 
             // Wait for "startService" log to be sent.
-            Task.WaitAny(startServiceTask, Task.Delay(5000));
-
+            await startServiceTask;
             DistributeEvent?.Invoke(this, DistributeTestType.OnResumeActivity);
 
             // Wait when Distribute will start.
@@ -115,17 +113,19 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
         [Fact]
         public async Task SetUpdateTrackPrivateTest()
         {
-            // Enable Distribute for debuggable builds.
-            DistributeEvent?.Invoke(this, DistributeTestType.EnableDebuggableBuilds);
 
             // Save data to preference.
             DistributeEvent?.Invoke(this, DistributeTestType.CheckUpdateAsync);
 
+            // Enable Distribute for debuggable builds.
+            DistributeEvent?.Invoke(this, DistributeTestType.EnableDebuggableBuilds);
+
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
-            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
-            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
+            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET", delayTimeInSeconds: 5);
+            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService", delayTimeInSeconds: 5);
+
 
             // Start AppCenter.
             AppCenter.UnsetInstance();
@@ -138,8 +138,7 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             AppCenter.Start(Config.ResolveAppSecret(), typeof(Distribute));
 
             // Wait for "startService" log to be sent.
-            Task.WaitAny(startServiceTask, Task.Delay(5000));
-
+            await startServiceTask;
             DistributeEvent?.Invoke(this, DistributeTestType.OnResumeActivity);
 
             // Wait when Distribute will start.

--- a/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
@@ -113,12 +113,11 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
         [Fact]
         public async Task SetUpdateTrackPrivateTest()
         {
+            // Enable Distribute for debuggable builds.
+            DistributeEvent?.Invoke(this, DistributeTestType.EnableDebuggableBuilds);
 
             // Save data to preference.
             DistributeEvent?.Invoke(this, DistributeTestType.CheckUpdateAsync);
-
-            // Enable Distribute for debuggable builds.
-            DistributeEvent?.Invoke(this, DistributeTestType.EnableDebuggableBuilds);
 
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();

--- a/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
@@ -125,7 +125,6 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
             var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
 
-
             // Start AppCenter.
             AppCenter.UnsetInstance();
             AppCenter.LogLevel = LogLevel.Verbose;

--- a/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/Distribute/DistributeUpdateTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
-            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET", delayTimeInSeconds: 5);
-            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService", delayTimeInSeconds: 5);
+            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
+            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
 
             // Start AppCenter.
             AppCenter.UnsetInstance();
@@ -82,8 +82,8 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
-            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET", delayTimeInSeconds: 5);
-            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService", delayTimeInSeconds: 5);
+            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
+            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
 
             // Start AppCenter.
             AppCenter.UnsetInstance();
@@ -123,8 +123,8 @@ namespace Microsoft.AppCenter.Test.Functional.Distribute
             // Setup network adapter.
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
-            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET", delayTimeInSeconds: 5);
-            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService", delayTimeInSeconds: 5);
+            var eventTask = httpNetworkAdapter.MockRequest(request => request.Method == "GET");
+            var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
 
 
             // Start AppCenter.

--- a/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AppCenter.Test.Functional
 {
     internal class ExpectedData
     {
-        private bool disposed = false;
+        private bool _disposed = false;
 
         internal HttpResponse Response { get; set; }
         internal Func<RequestData, bool> Where { get; set; }
@@ -18,7 +18,6 @@ namespace Microsoft.AppCenter.Test.Functional
 
         internal ExpectedData(TimeSpan tokenTimeout)
         {
-
             // Since we can't directly assign token to a Task created with FromResult,
             // and we can't work with token in SendAsync because it may or may not be called after this method,
             // we are registering anonymous cancellation token here.
@@ -35,17 +34,14 @@ namespace Microsoft.AppCenter.Test.Functional
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (!_disposed)
             {
-                if (disposing)
-                {
-                    UnregisterToken();
-                    Response = null;
-                    Where = null;
-                    Response = null;
-                    TaskCompletionSource = null;
-                }
-                disposed = true;
+                UnregisterToken();
+                Response = null;
+                Where = null;
+                Response = null;
+                TaskCompletionSource = null;
+                _disposed = true;
             }
         }
 

--- a/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
@@ -9,9 +9,49 @@ namespace Microsoft.AppCenter.Test.Functional
 {
     internal class ExpectedData
     {
+        private bool disposed = false;
+
         internal HttpResponse Response { get; set; }
         internal Func<RequestData, bool> Where { get; set; }
         internal TaskCompletionSource<RequestData> TaskCompletionSource { get; set; }
-        internal CancellationTokenSource cancellationTokenSource { get; set; }
+        internal CancellationTokenSource CancellationSource { get; set; }
+
+        internal ExpectedData(TimeSpan tokenTimeout)
+        {
+
+            // Since we can't directly assign token to a Task created with FromResult,
+            // and we can't work with token in SendAsync because it may or may not be called after this method,
+            // we are registering anonymous cancellation token here.
+            // The only weak point can occur if there's a significant delay between actual Task creation time and calling this method,
+            // but since we only use that in tests, that can be ignored.
+            CancellationSource = new CancellationTokenSource(tokenTimeout);
+            CancellationSource.Token.Register(() => TaskCompletionSource.TrySetCanceled());
+        }
+
+        public void UnregisterToken()
+        {
+            CancellationSource.Dispose();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    UnregisterToken();
+                    Response = null;
+                    Where = null;
+                    Response = null;
+                    TaskCompletionSource = null;
+                }
+                disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
@@ -9,45 +9,42 @@ namespace Microsoft.AppCenter.Test.Functional
 {
      internal class ExpectedData : IDisposable
     {
-        private bool _disposed = false;
-
         internal HttpResponse Response { get; set; }
         internal Func<RequestData, bool> Where { get; set; }
-        internal TaskCompletionSource<RequestData> TaskCompletionSource { get; set; }
-        internal CancellationTokenSource CancellationSource { get; set; }
+        private TaskCompletionSource<RequestData> _taskCompletionSource { get; set; }
+        private CancellationTokenSource _cancellationSource { get; set; }
 
         internal ExpectedData(TimeSpan tokenTimeout)
         {
+            _taskCompletionSource = new TaskCompletionSource<RequestData>();
+
             // Since we can't directly assign token to a Task created with FromResult,
             // and we can't work with token in SendAsync because it may or may not be called after this method,
             // we are registering anonymous cancellation token here.
             // The only weak point can occur if there's a significant delay between actual Task creation time and calling this method,
             // but since we only use that in tests, that can be ignored.
-            CancellationSource = new CancellationTokenSource(tokenTimeout);
-            CancellationSource.Token.Register(() => TaskCompletionSource.TrySetCanceled());
+            _cancellationSource = new CancellationTokenSource(tokenTimeout);
+            _cancellationSource.Token.Register(() => _taskCompletionSource.TrySetCanceled());
+        }
+
+        public bool TrySetResult(RequestData requestData)
+        {
+            return _taskCompletionSource.TrySetResult(requestData);
+        }
+
+        public Task<RequestData> GetTask()
+        {
+            return _taskCompletionSource.Task;
         }
 
         public void UnregisterToken()
         {
-            CancellationSource.Dispose();
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                UnregisterToken();
-                Response = null;
-                Where = null;
-                Response = null;
-                TaskCompletionSource = null;
-                _disposed = true;
-            }
+            _cancellationSource.Dispose();
         }
 
         public void Dispose()
         {
-            Dispose(true);
+            UnregisterToken();
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Test.Functional
 {
-    internal class ExpectedData
+     internal class ExpectedData : IDisposable
     {
         private bool _disposed = false;
 

--- a/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.AppCenter.Test.Functional
@@ -11,5 +12,6 @@ namespace Microsoft.AppCenter.Test.Functional
         internal HttpResponse Response { get; set; }
         internal Func<RequestData, bool> Where { get; set; }
         internal TaskCompletionSource<RequestData> TaskCompletionSource { get; set; }
+        internal CancellationTokenSource cancellationTokenSource { get; set; }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/ExpectedData.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AppCenter.Test.Functional
     internal class ExpectedData : IDisposable
     {
         private readonly TaskCompletionSource<RequestData> _taskCompletionSource = new TaskCompletionSource<RequestData>();
+
         private readonly CancellationTokenSource _cancellationSource;
 
         public HttpResponse Response { get; set; }

--- a/Tests/Microsoft.AppCenter.Test.Functional/HttpNetworkAdapter.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/HttpNetworkAdapter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AppCenter.Test.Functional
                 Where = where,
             };
             expectedDataList.Add(expectedData);
-            return expectedData.GetTask();
+            return expectedData.Task;
         }
 
         public Task<HttpResponse> SendAsync(string uri, string method, IDictionary<string, string> headers, string jsonContent, CancellationToken cancellationToken)
@@ -48,8 +48,8 @@ namespace Microsoft.AppCenter.Test.Functional
                     if (result)
                     {
                         CallCount++;
-                        rule.TrySetResult(requestData);
-                        rule.UnregisterToken();
+                        rule.SetResult(requestData);
+                        rule.Dispose();
                         expectedDataList.Remove(rule);
                         return Task.FromResult(rule.Response);
                     }
@@ -60,6 +60,11 @@ namespace Microsoft.AppCenter.Test.Functional
         
         public void Dispose()
         {
+            foreach (var rule in expectedDataList)
+            {
+                rule.Dispose();
+            }
+            expectedDataList.Clear();
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Functional/HttpNetworkAdapter.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/HttpNetworkAdapter.cs
@@ -21,12 +21,12 @@ namespace Microsoft.AppCenter.Test.Functional
 
         internal int CallCount { get; private set; }
 
-        public Task<RequestData> MockRequestByLogType(string logType, HttpResponse response = null, double delayTimeInSeconds = 5)
+        public Task<RequestData> MockRequestByLogType(string logType, HttpResponse response = null, double delayTimeInSeconds = 20)
         {
             return MockRequest(request => request.JsonContent.SelectTokens($"$.logs[?(@.type == '{logType}')]").ToList().Count > 0, response, delayTimeInSeconds);
         }
 
-        public Task<RequestData> MockRequest(Func<RequestData, bool> where, HttpResponse response = null, double delayTimeInSeconds = 5)
+        public Task<RequestData> MockRequest(Func<RequestData, bool> where, HttpResponse response = null, double delayTimeInSeconds = 20)
         {
             var expectedData = new ExpectedData
             {

--- a/Tests/Microsoft.AppCenter.Test.Functional/HttpNetworkAdapter.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/HttpNetworkAdapter.cs
@@ -32,10 +32,9 @@ namespace Microsoft.AppCenter.Test.Functional
             {
                 Response = response ?? DefaultHttpResponse,
                 Where = where,
-                TaskCompletionSource = new TaskCompletionSource<RequestData>()
             };
             expectedDataList.Add(expectedData);
-            return expectedData.TaskCompletionSource.Task;
+            return expectedData.GetTask();
         }
 
         public Task<HttpResponse> SendAsync(string uri, string method, IDictionary<string, string> headers, string jsonContent, CancellationToken cancellationToken)
@@ -49,7 +48,7 @@ namespace Microsoft.AppCenter.Test.Functional
                     if (result)
                     {
                         CallCount++;
-                        rule.TaskCompletionSource.TrySetResult(requestData);
+                        rule.TrySetResult(requestData);
                         rule.UnregisterToken();
                         expectedDataList.Remove(rule);
                         return Task.FromResult(rule.Response);


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR will fix cancellation token behaviour in httpNetworkAdapter. Previously it was ignored, forcing us to use `Task.WaitAny` in tests to create a timeout. 

## Related PRs or issues

Commits in this PR were cut from different branch so there is no WI for this PR to link, aside from [AB#75371](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/75371)