### PR TITLE
App crash due to 'App Center' corrupted configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ App Center Data is [retired](https://aka.ms/MBaaS-retirement-blog-post) and has 
 
 * **[Fix]** Allow whitespace characters between secrets like in versions before `2.6.0`.
 
-#### WPF
+#### WPF / WinForms
 
 * **[Fix]** Fix application crash when the `AppCenter` configuration file is corrupted.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ App Center Data is [retired](https://aka.ms/MBaaS-retirement-blog-post) and has 
 
 * **[Fix]** Allow whitespace characters between secrets like in versions before `2.6.0`.
 
+#### WPF
+
+* **[Fix]** Fix application crash when the `App Center` configuration file is corrupted.
+
 ### App Center Distribute
 
 * **[Feature]** Add `UpdateTrack` property to be able to explicitly set either `Private` or `Public` update track. By default, a public distribution group is used. **Breaking change**: To allow users to access releases of private groups you now need to migrate your application to call `Distribute.UpdateTrack = UpdateTrack.Private` before the SDK start. Please read the documentation for more details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ App Center Data is [retired](https://aka.ms/MBaaS-retirement-blog-post) and has 
 
 #### WPF
 
-* **[Fix]** Fix application crash when the `App Center` configuration file is corrupted.
+* **[Fix]** Fix application crash when the `AppCenter` configuration file is corrupted.
 
 ### App Center Distribute
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -198,7 +198,7 @@ namespace Microsoft.AppCenter.Utils
             }
             catch (ConfigurationErrorsException e)
             {
-                AppCenterLog.Warn(AppCenterLog.LogTag, "Could not backup config file", e);
+                AppCenterLog.Warn(AppCenterLog.LogTag, "Could not back up the configuration file.", e);
             }
         }
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AppCenter.Utils
                 try
                 {
                     configuration = OpenConfiguration();
-                    CrateConfigurationFileBackup();
+                    CreateConfigurationFileBackup();
                 }
                 catch (Exception e)
                 {
@@ -194,14 +194,13 @@ namespace Microsoft.AppCenter.Utils
             return ConfigurationManager.OpenMappedExeConfiguration(executionFileMap, ConfigurationUserLevel.None);
         }
 
-        private void CrateConfigurationFileBackup()
+        private void CreateConfigurationFileBackup()
         {
             try
             {
-                XDocument configurationFile = XDocument.Load(FilePath);
-                configurationFile.Save(BackupFilePath);
+                configuration.SaveAs(BackupFilePath);
             }
-            catch (XmlException e)
+            catch (ConfigurationErrorsException e)
             {
                 AppCenterLog.Warn(AppCenterLog.LogTag, "Could not backup config file", e);
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AppCenter.Utils
                 }
                 catch (Exception e)
                 {
-                    AppCenterLog.Error(AppCenterLog.LogTag, "Configuration file could be corrupted.", e);
+                    AppCenterLog.Error(AppCenterLog.LogTag, "Configuration could be corrupted.", e);
                     RestoreConfigurationFile();
                 }
             }
@@ -40,10 +40,10 @@ namespace Microsoft.AppCenter.Utils
             {
                 if (configuration != null)
                 {
-                    var value = configuration.AppSettings.Settings[key];
-                    if (value != null)
+                    var setting = configuration.AppSettings.Settings[key];
+                    if (setting != null)
                     {
-                        return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString(value.Value);
+                        return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString(setting.Value);
                     }
                 }
                 else
@@ -184,12 +184,12 @@ namespace Microsoft.AppCenter.Utils
                 {
                     File.Delete(FilePath);
                     configuration = OpenConfiguration();
-                    AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file is successfully restored.");
+                    AppCenterLog.Info(AppCenterLog.LogTag, "Configuration is successfully restored.");
                 }
             }
             catch (Exception e)
             {
-                AppCenterLog.Warn(AppCenterLog.LogTag, "Could not restore configuration file.", e);
+                AppCenterLog.Warn(AppCenterLog.LogTag, "Could not restore configuration.", e);
             }
         }
     }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -184,8 +184,8 @@ namespace Microsoft.AppCenter.Utils
                 {
                     File.Delete(FilePath);
                     configuration = OpenConfiguration();
+                    AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file is successfully restored.");
                 }
-                AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file is successfully restored.");
             }
             catch (Exception e)
             {

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -76,7 +76,6 @@ namespace Microsoft.AppCenter.Utils
                     AppCenterLog.Warn(AppCenterLog.LogTag, $"{CorruptedConfigurationWarning} Method 'ContainsKey', key:{key}");
                 }
             }
-
             return false;
         }
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AppCenter.Utils
     {
         private const string FileName = "AppCenter.config";
         private const string BackupFileName = "AppCenter.config.bak";
-        private const string CorruptedConfigurationWarning = "Configuration is corrupted. App Center could work incorrectly";
+        private const string CorruptedConfigurationWarning = "Configuration is corrupted. App Center could work incorrectly.";
         private static readonly object configLock = new object();
         private static Configuration configuration;
 
@@ -31,7 +31,7 @@ namespace Microsoft.AppCenter.Utils
                     configuration = OpenConfiguration();
                     CreateConfigurationFileBackup();
                 }
-                catch (Exception e) when (e is XmlException || e is ConfigurationErrorsException)
+                catch (Exception e)
                 {
                     AppCenterLog.Error(AppCenterLog.LogTag, "Configuration file could be corrupted", e);
                     if (RestoreConfigurationFile())
@@ -56,7 +56,7 @@ namespace Microsoft.AppCenter.Utils
                 }
                 else
                 {
-                    AppCenterLog.Warn(AppCenterLog.LogTag, CorruptedConfigurationWarning);
+                    AppCenterLog.Warn(AppCenterLog.LogTag, $"{CorruptedConfigurationWarning} Method 'GetValue', key:{key}");
                 }
             }
             return defaultValue;
@@ -81,7 +81,7 @@ namespace Microsoft.AppCenter.Utils
                 }
                 else
                 {
-                    AppCenterLog.Warn(AppCenterLog.LogTag, CorruptedConfigurationWarning);
+                    AppCenterLog.Warn(AppCenterLog.LogTag, $"{CorruptedConfigurationWarning} Method 'ContainsKey', key:{key}");
                 }
             }
 
@@ -99,7 +99,7 @@ namespace Microsoft.AppCenter.Utils
                 }
                 else
                 {
-                    AppCenterLog.Warn(AppCenterLog.LogTag, CorruptedConfigurationWarning);
+                    AppCenterLog.Warn(AppCenterLog.LogTag, $"{CorruptedConfigurationWarning} Method 'Remove', key:{key}");
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace Microsoft.AppCenter.Utils
                 }
                 else
                 {
-                    AppCenterLog.Warn(AppCenterLog.LogTag, CorruptedConfigurationWarning);
+                    AppCenterLog.Warn(AppCenterLog.LogTag, $"{CorruptedConfigurationWarning} Method 'SaveValue', key:{key}, value:{value}");
                 }
             }
         }
@@ -207,12 +207,12 @@ namespace Microsoft.AppCenter.Utils
             try
             {
                 File.Copy(BackupFilePath, FilePath, true);
-                AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file restored from backup");
+                AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file is successfully restored from backup.");
                 return true;
             }
             catch (Exception e)
             {
-                AppCenterLog.Warn(AppCenterLog.LogTag, "Could not restore config file", e);
+                AppCenterLog.Warn(AppCenterLog.LogTag, "Could not restore configuration file.", e);
             }
 
             return false;

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DefaultApplicationSettings.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AppCenter.Utils
                 }
                 catch (Exception e)
                 {
-                    AppCenterLog.Error(AppCenterLog.LogTag, "Configuration file could be corrupted", e);
+                    AppCenterLog.Error(AppCenterLog.LogTag, "Configuration file could be corrupted.", e);
                     RestoreConfigurationFile();
                 }
             }
@@ -185,7 +185,7 @@ namespace Microsoft.AppCenter.Utils
                     File.Delete(FilePath);
                     configuration = OpenConfiguration();
                 }
-                AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file is successfully restored from backup.");
+                AppCenterLog.Info(AppCenterLog.LogTag, "Configuration file is successfully restored.");
             }
             catch (Exception e)
             {

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
@@ -4,7 +4,6 @@
 using Microsoft.AppCenter.Utils;
 using System;
 using System.IO;
-using System.Reflection;
 using Xunit;
 
 namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
@@ -106,6 +105,22 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
 
             // Check migration didn't happen.
             Assert.Equal("newValue", _settings.GetValue<string>("key"));
+        }
+
+        [Fact]
+        public void VerifyThatCorruptedConfigRestored()
+        {
+            Assert.True(File.Exists(DefaultApplicationSettings.BackupFilePath));
+            string[] originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
+            string[] backupLines = File.ReadAllLines(DefaultApplicationSettings.BackupFilePath);
+            Assert.Equal(originalLines, backupLines);
+            string[] corruptedLines = new string[originalLines.Length - 2];
+            Array.Copy(originalLines, 0, corruptedLines, 0, corruptedLines.Length);
+            Assert.NotEqual(corruptedLines, backupLines);
+            File.WriteAllLines(DefaultApplicationSettings.FilePath, corruptedLines);
+            _settings = new DefaultApplicationSettings();
+            originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
+            Assert.Equal(originalLines, backupLines);
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
@@ -107,21 +107,5 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
             // Check migration didn't happen.
             Assert.Equal("newValue", _settings.GetValue<string>("key"));
         }
-
-        [Fact]
-        public void VerifyThatCorruptedConfigRestored()
-        {
-            Assert.True(File.Exists(DefaultApplicationSettings.BackupFilePath));
-            string[] originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
-            string[] backupLines = File.ReadAllLines(DefaultApplicationSettings.BackupFilePath);
-            Assert.Equal(originalLines, backupLines);
-            string[] corruptedLines = new string[originalLines.Length - 2];
-            Array.Copy(originalLines, 0, corruptedLines, 0, corruptedLines.Length);
-            Assert.NotEqual(corruptedLines, backupLines);
-            File.WriteAllLines(DefaultApplicationSettings.FilePath, corruptedLines);
-            _settings = new DefaultApplicationSettings();
-            originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
-            Assert.Equal(originalLines, backupLines);
-        }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
             try
             {
                 File.Delete(DefaultApplicationSettings.FilePath);
+                File.Delete(DefaultApplicationSettings.BackupFilePath);
             }
             catch (Exception)
             {
@@ -105,6 +106,22 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
 
             // Check migration didn't happen.
             Assert.Equal("newValue", _settings.GetValue<string>("key"));
+        }
+
+        [Fact]
+        public void VerifyThatCorruptedConfigRestored()
+        {
+            Assert.True(File.Exists(DefaultApplicationSettings.BackupFilePath));
+            string[] originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
+            string[] backupLines = File.ReadAllLines(DefaultApplicationSettings.BackupFilePath);
+            Assert.Equal(originalLines, backupLines);
+            string[] corruptedLines = new string[originalLines.Length - 2];
+            Array.Copy(originalLines, 0, corruptedLines, 0, corruptedLines.Length);
+            Assert.NotEqual(corruptedLines, backupLines);
+            File.WriteAllLines(DefaultApplicationSettings.FilePath, corruptedLines);
+            _settings = new DefaultApplicationSettings();
+            originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
+            Assert.Equal(originalLines, backupLines);
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Utils/ApplicationSettingsTest.cs
@@ -22,7 +22,6 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
             try
             {
                 File.Delete(DefaultApplicationSettings.FilePath);
-                File.Delete(DefaultApplicationSettings.BackupFilePath);
             }
             catch (Exception)
             {
@@ -110,17 +109,17 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
         [Fact]
         public void VerifyThatCorruptedConfigRestored()
         {
-            Assert.True(File.Exists(DefaultApplicationSettings.BackupFilePath));
-            string[] originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
-            string[] backupLines = File.ReadAllLines(DefaultApplicationSettings.BackupFilePath);
-            Assert.Equal(originalLines, backupLines);
-            string[] corruptedLines = new string[originalLines.Length - 2];
-            Array.Copy(originalLines, 0, corruptedLines, 0, corruptedLines.Length);
-            Assert.NotEqual(corruptedLines, backupLines);
+            _settings.SetValue("old", "value");
+            _settings.Remove("old");
+            var expectedLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
+            var corruptedLines = new string[expectedLines.Length - 2];
+            Array.Copy(expectedLines, 0, corruptedLines, 0, corruptedLines.Length);
             File.WriteAllLines(DefaultApplicationSettings.FilePath, corruptedLines);
             _settings = new DefaultApplicationSettings();
-            originalLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
-            Assert.Equal(originalLines, backupLines);
+            _settings.SetValue("old", "value");
+            _settings.Remove("old");
+            var actualLines = File.ReadAllLines(DefaultApplicationSettings.FilePath);
+            Assert.Equal(expectedLines, actualLines);
         }
     }
 }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

If the 'App Center' configuration file is corrupted then the application could not work. The logic which restores this file was added. If the configuration could not be restored the application does not crash.

## Related PRs or issues

[AB#75523](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/75523)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1303
