### PR TITLE
Remove warning about attachments amount when sending crash report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 3.1.1 (Under development)
 
+### App Center Crashes
+
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
 
 ___

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 3.1.1 (Under development)
 
+* **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
+
 ___
 
 ## Version 3.1.0

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -21,8 +21,6 @@ namespace Microsoft.AppCenter.Crashes
 
         private static Crashes _instanceField;
 
-        private const int MaxAttachmentsPerCrash = 2;
-
         private const int MaxAttachmentSize = 7 * 1024 * 1024;
 
         internal const string PrefKeyAlwaysSend = Constants.KeyPrefix + "CrashesAlwaysSend";

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Windows.Shared/Crashes.cs
@@ -395,7 +395,6 @@ namespace Microsoft.AppCenter.Crashes
 
         private Task SendErrorAttachmentsAsync(Guid errorId, IEnumerable<ErrorAttachmentLog> attachments)
         {
-            var totalErrorAttachments = 0;
             var tasks = new List<Task>();
             foreach (var attachment in attachments)
             {
@@ -413,7 +412,6 @@ namespace Microsoft.AppCenter.Crashes
                     }
                     else
                     {
-                        ++totalErrorAttachments;
                         tasks.Add(Channel.EnqueueAsync(attachment));
                     }
                 }
@@ -421,10 +419,6 @@ namespace Microsoft.AppCenter.Crashes
                 {
                     AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog.");
                 }
-            }
-            if (totalErrorAttachments > MaxAttachmentsPerCrash)
-            {
-                AppCenterLog.Warn(LogTag, $"A limit of {MaxAttachmentsPerCrash} attachments per error report might be enforced by server.");
             }
             return Task.WhenAll(tasks);
         }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR removes warning about attachments count when sending crash.
With that, constant and local counter are now not necessary, too.

## Related PRs or issues

[AB#78240](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78240)