### PR TITLE
Fix reporting WPF versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 3.1.1 (Under development)
 
+### App Center
+
+#### WPF
+
+* **[Fix]** Fix app build version reporting, the assembly file version is used for this field now.
+
 ### App Center Crashes
 
 * **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center
 
-#### WPF
+#### WPF/WinForms
 
 * **[Fix]** Fix app build version reporting, the assembly file version is used for this field now.
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -118,8 +118,14 @@ namespace Microsoft.AppCenter.Utils
 #endif
             // The AssemblyFileVersion uniquely identifys a build.
             var entryAssembly = Assembly.GetEntryAssembly();
-            var fileVersionInfo = FileVersionInfo.GetVersionInfo(entryAssembly.Location);
-            return fileVersionInfo.FileVersion;
+            if (entryAssembly != null)
+            {
+                var fileVersionInfo = FileVersionInfo.GetVersionInfo(entryAssembly.Location);
+                return fileVersionInfo.FileVersion;
+            }
+
+            // Fallback if entry assembly is not found (in unit tests for example).
+            return GetAppVersion();
         }
 
         protected override string GetScreenSize()


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Currently, SDK incorrectly uses the same version for both fields. "appBuild" field should contains exact number of specific build to improve grouping of problems on portal.

Some info about difference between versions:

`AssemblyInformationalVersion` - the product version of the assembly. This is the version you would use when talking to customers or for display on your website. This version can be a string, like '1.0 Release Candidate'. Optional. If not given, the `AssemblyFileVersion` is used.

`AssemblyFileVersion` is intended to uniquely identify a build. It can be increased for every deployment/build.

Also see [a good descriptions on StackOverflow](https://stackoverflow.com/questions/64602).

## Related PRs or issues

[AB#79013](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/79013)