### PR TITLE
The "Clear Crash User Confirmation" doesn't work

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/AppDelegate.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/AppDelegate.cs
@@ -15,7 +15,7 @@ namespace Contoso.Forms.Demo.iOS
     [Register("AppDelegate")]
     public class AppDelegate : Xamarin.Forms.Platform.iOS.FormsApplicationDelegate, IClearCrashClick
     {
-        private const string CrashesUserConfirmationStorageKey = "MSUserConfirmation";
+        private const string CrashesUserConfirmationStorageKey = "MSAppCenterCrashesUserConfirmation";
 
         public override bool FinishedLaunching(UIApplication uiApplication, NSDictionary launchOptions)
         {

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/AppDelegate.cs
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/AppDelegate.cs
@@ -15,7 +15,7 @@ namespace Contoso.Forms.Puppet.iOS
     [Register("AppDelegate")]
     public class AppDelegate : Xamarin.Forms.Platform.iOS.FormsApplicationDelegate, IClearCrashClick
     {
-        private const string CrashesUserConfirmationStorageKey = "MSUserConfirmation";
+        private const string CrashesUserConfirmationStorageKey = "MSAppCenterCrashesUserConfirmation";
 
         public override bool FinishedLaunching(UIApplication uiApplication, NSDictionary launchOptions)
         {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

**Repro Steps**

- Install the DotNet iOS demo app
- Crash the application using the in app controls
- Restart app and select Always Send 
- Click the Clear Crash User Confirmation button
- Crash the application using the in app controls again and restart app

**Expected Behaviour**
When the app is restarted, a dialog will appear to send a crash report

**Actual Behaviour**
When the app is restarted, there is no dialog to send a crash report

## Related PRs or issues

[AB#80622](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/80622)
