### PR TITLE
SDK crashes when try to track error with attachments equals to null 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 #### iOS
 
 * **[Improvement]** Update PLCrashReporter to 1.7.0.
-* **[Fix]** Fix TrackError when attachments are null.
+* **[Fix]** Add attachments verification in `TrackError` function to handle explicitly passed `null` array to variable arguments parameter.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 #### iOS
 
 * **[Improvement]** Update PLCrashReporter to 1.7.0.
+* **[Fix]** Fix TrackError when attachments are null.
 
 ___
 

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS/Crashes.cs
@@ -77,15 +77,18 @@ namespace Microsoft.AppCenter.Crashes
         {
             NSDictionary propertyDictionary = properties != null ? StringDictToNSDict(properties) : new NSDictionary();
             NSMutableArray attachmentArray = new NSMutableArray();
-            foreach (var attachment in attachments)
+            if (attachments != null)
             {
-                if (attachment?.internalAttachment != null)
+                foreach (var attachment in attachments)
                 {
-                    attachmentArray.Add(attachment.internalAttachment);
-                }
-                else
-                {
-                    AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog in Crashes.TrackError.");
+                    if (attachment?.internalAttachment != null)
+                    {
+                        attachmentArray.Add(attachment.internalAttachment);
+                    }
+                    else
+                    {
+                        AppCenterLog.Warn(LogTag, "Skipping null ErrorAttachmentLog in Crashes.TrackError.");
+                    }
                 }
             }
             MSWrapperCrashesHelper.TrackModelException(GenerateiOSException(exception, false), propertyDictionary, attachmentArray);

--- a/Tests/Microsoft.AppCenter.Test.Functional/Crashes/AppCenterCrashesTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Functional/Crashes/AppCenterCrashesTest.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AppCenter.Test.Functional.Crashes
             var httpNetworkAdapter = new HttpNetworkAdapter();
             DependencyConfiguration.HttpNetworkAdapter = httpNetworkAdapter;
             var startServiceTask = httpNetworkAdapter.MockRequestByLogType("startService");
-            var eventTask = httpNetworkAdapter.MockRequestByLogType(typeEvent);
+            var eventTask1 = httpNetworkAdapter.MockRequestByLogType(typeEvent);
+            var eventTask2 = httpNetworkAdapter.MockRequestByLogType(typeEvent);
 
             // Start App Center.
             AppCenter.LogLevel = LogLevel.Verbose;
@@ -39,10 +40,17 @@ namespace Microsoft.AppCenter.Test.Functional.Crashes
             // Wait for "startService" log to be sent.
             await startServiceTask;
 
-            Crashes.TrackError(new Exception("The answert is 42"));
-            RequestData requestData = await eventTask;
-            var events = requestData.JsonContent.SelectTokens($"$.logs[?(@.type == '{typeEvent}')]").ToList();
-            Assert.Equal(1, events.Count());
+            // Check track error without attachments.
+            Crashes.TrackError(new Exception("The answert is 1"));
+            RequestData requestData1 = await eventTask1;
+            var events1 = requestData1.JsonContent.SelectTokens($"$.logs[?(@.type == '{typeEvent}')]").ToList();
+            Assert.Single(events1);
+
+            // Check track error when attachments are null.
+            Crashes.TrackError(new Exception("The answert is 2"), null, null);
+            RequestData requestData2 = await eventTask2;
+            var events2 = requestData2.JsonContent.SelectTokens($"$.logs[?(@.type == '{typeEvent}')]").ToList();
+            Assert.Single(events2);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Call method `Crashes.TrackError(ex, null, null);` from anywhere in the test application.

**Expected behavior:** Error should be correctly tracked.

**Actual behavior:** Sdk crashes.

## Related PRs or issues

[AB#81630](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81630)
