### PR TITLE
Fix CodeQL build on Mac

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,6 @@ jobs:
         msbuild SDK/AppCenter/Microsoft.AppCenter/Microsoft.AppCenter.csproj /p:Configuration=Release /restore /t:Build
         msbuild SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Microsoft.AppCenter.Analytics.csproj /p:UseSharedCompilation=false /restore /t:Build
         msbuild SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes/Microsoft.AppCenter.Crashes.csproj /p:UseSharedCompilation=false /restore /t:Build
-        msbuild SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute/Microsoft.AppCenter.Distribute.csproj /p:UseSharedCompilation=false /restore /t:Build
         msbuild SDK/AppCenterPush/Microsoft.AppCenter.Push/Microsoft.AppCenter.Push.csproj /p:UseSharedCompilation=false /restore /t:Build
 
     - run: |
@@ -91,10 +90,11 @@ jobs:
         Remove-Item -Path NuGet.config
     
     - run: |
-        echo "Restore App Center Dependencies"
+        echo "Restore App Center Dependencies and Build"
         $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         MSBuild.exe AppCenter-SDK-Build-Windows.sln -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build 
-        
+        MSBuild.exe SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute/Microsoft.AppCenter.Distribute.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build
+
     - run: |
         echo "Build App Center For Android"
         $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,13 +37,6 @@ jobs:
         ./build.sh -target="Externals-iOS"
 
     - run: |
-        echo "Build App Center"
-        msbuild SDK/AppCenter/Microsoft.AppCenter/Microsoft.AppCenter.csproj /p:Configuration=Release /restore /t:Build
-        msbuild SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Microsoft.AppCenter.Analytics.csproj /p:UseSharedCompilation=false /restore /t:Build
-        msbuild SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes/Microsoft.AppCenter.Crashes.csproj /p:UseSharedCompilation=false /restore /t:Build
-        msbuild SDK/AppCenterPush/Microsoft.AppCenter.Push/Microsoft.AppCenter.Push.csproj /p:UseSharedCompilation=false /restore /t:Build
-
-    - run: |
         echo "Build App Center For iOS"
         msbuild SDK/AppCenter/Microsoft.AppCenter.iOS/Microsoft.AppCenter.iOS.csproj /p:Configuration=Release /restore /t:Build
         msbuild SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS/Microsoft.AppCenter.Analytics.iOS.csproj /p:UseSharedCompilation=false /restore /t:Build
@@ -93,7 +86,11 @@ jobs:
         echo "Restore App Center Dependencies and Build"
         $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         MSBuild.exe AppCenter-SDK-Build-Windows.sln -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build 
+        MSBuild.exe SDK/AppCenter/Microsoft.AppCenter/Microsoft.AppCenter.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build
+        MSBuild.exe SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics/Microsoft.AppCenter.Analytics.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build
+        MSBuild.exe SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes/Microsoft.AppCenter.Crashes.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build
         MSBuild.exe SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute/Microsoft.AppCenter.Distribute.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build
+        MSBuild.exe SDK/AppCenterPush/Microsoft.AppCenter.Push/Microsoft.AppCenter.Push.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build
 
     - run: |
         echo "Build App Center For Android"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,10 +83,6 @@ jobs:
         Remove-Item -Path NuGet.config
     
     - run: |
-        echo "Restore App Center Dependencies"
-        $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
-
-    - run: |
         echo "Build App Center"
         $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         MSBuild.exe AppCenter-SDK-Build-Windows.sln -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,7 +83,11 @@ jobs:
         Remove-Item -Path NuGet.config
     
     - run: |
-        echo "Restore App Center Dependencies and Build"
+        echo "Restore App Center Dependencies"
+        $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
+
+    - run: |
+        echo "Build App Center"
         $Env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         MSBuild.exe AppCenter-SDK-Build-Windows.sln -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build 
         MSBuild.exe SDK/AppCenter/Microsoft.AppCenter/Microsoft.AppCenter.csproj -property:UseSharedCompilation=false -property:Configuration=Release /restore -target:Build


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [ ] ~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

The CodeQL build failed on Mac after adding support `MonoAndroid` to `TargetFrameworks` for the `Distribute` project.

## Related PRs or issues

[AB#82098](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82098)
