### PR TITLE
Fix send attachments with null parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Version 3.4.2 (Under development)
 
+### App Center Crashes
+
+#### iOS
+
+* **[Fix]** Fix sending attachments with a null text value.
+
 ___
 
 ## Version 3.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### iOS
 
-* **[Fix]** Fix sending attachments with a null text value.
+* **[Fix]** Fix sending attachments with a `null` text value.
 
 ___
 

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/ApiDefinition.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/ApiDefinition.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AppCenter.Crashes.iOS.Bindings
         // + (MSErrorAttachmentLog *)attachmentWithText:(NSString *)text filename:(NSString *)filename;
         [Static]
         [Export("attachmentWithText:filename:")]
-        MSErrorAttachmentLog AttachmentWithText(string text, [NullAllowed] string fileName);
+        MSErrorAttachmentLog AttachmentWithText([NullAllowed] string text, [NullAllowed] string fileName);
 
         // + (MSErrorAttachmentLog *)attachmentWithBinary:(NSData *)data filename:(NSString*)filename contentType:(NSString*)contentType;
         [Static]


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Repo steps:
Call this method after AppCenter start.
`ErrorAttachmentLog.AttachmentWithText(null, "test.txt");`

## Related PRs or issues

[AB#82668](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82668)

