### PR TITLE
Old logs deletion when storage is full

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Microsoft.AppCenter.Windows.Shared.projitems
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Microsoft.AppCenter.Windows.Shared.projitems
@@ -35,6 +35,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ingestion\Models\ValidationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Storage\IStorageAdapter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Storage\StorageAdapter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Storage\StorageFullException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\UserIdEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\SessionContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\Constants.cs" />

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
@@ -81,5 +81,11 @@ namespace Microsoft.AppCenter.Storage
         /// </summary>
         /// <returns>The maximum size of database in bytes.</returns>
         long GetMaxStorageSize();
+
+        /// <summary>
+        /// Gets the current size of the database.
+        /// </summary>
+        /// <returns>The current size of database in bytes.</returns>
+        long GetCurrentStorageSize();
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AppCenter.Storage
         /// <param name="excludeColumnName">Column name to match excluded values by.</param>
         /// <param name="excludeValues">Excluded values to match in query.</param>
         /// <param name="limit">Maximum amount of items to select.</param>
+        /// <param name="orderList">List of a column names to order selection result ascending.</param>
         /// <returns>Item list with array of objects. Array of objects is object[] representation of columns.</returns>
         IList<object[]> Select(string tableName, string columnName, object value, string excludeColumnName, object[] excludeValues, int? limit = null, string[] orderList = null);
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
@@ -82,11 +82,5 @@ namespace Microsoft.AppCenter.Storage
         /// </summary>
         /// <returns>The maximum size of database in bytes.</returns>
         long GetMaxStorageSize();
-
-        /// <summary>
-        /// Gets the current size of the database.
-        /// </summary>
-        /// <returns>The current size of database in bytes.</returns>
-        long GetCurrentStorageSize();
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/IStorageAdapter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AppCenter.Storage
         /// <param name="excludeValues">Excluded values to match in query.</param>
         /// <param name="limit">Maximum amount of items to select.</param>
         /// <returns>Item list with array of objects. Array of objects is object[] representation of columns.</returns>
-        IList<object[]> Select(string tableName, string columnName, object value, string excludeColumnName, object[] excludeValues, int? limit = null);
+        IList<object[]> Select(string tableName, string columnName, object value, string excludeColumnName, object[] excludeValues, int? limit = null, string[] orderList = null);
 
         /// <summary>
         /// Inserts data to table.
@@ -75,5 +75,11 @@ namespace Microsoft.AppCenter.Storage
         /// </param>
         /// <returns><code>true</code> if changing the size was successful.</returns>
         bool SetMaxStorageSize(long sizeInBytes);
+
+        /// <summary>
+        /// Gets the maximum size of the database.
+        /// </summary>
+        /// <returns>The maximum size of database in bytes.</returns>
+        long GetMaxStorageSize();
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AppCenter.Ingestion.Models;
@@ -85,11 +86,38 @@ namespace Microsoft.AppCenter.Storage
             return AddTaskToQueue(() =>
             {
                 var logJsonString = LogSerializer.Serialize(log);
-                _storageAdapter.Insert(TableName,
-                    new[] { ColumnChannelName, ColumnLogName },
-                    new List<object[]> {
-                        new object[] {channelName, logJsonString}
-                    });
+                var maxSize = _storageAdapter.GetMaxStorageSize();
+                var logSize = Encoding.UTF8.GetBytes(logJsonString).Length;
+                if (maxSize == -1)
+                {
+                    throw new StorageException("Failed to store a log to the database.");
+                }
+                if (maxSize <= logSize)
+                {
+                    throw new StorageException($"Log is too large ({logSize} bytes) to store in database. " +
+                            $"Current maximum database size is {maxSize} bytes.");
+                }
+                var tryInsert = true;
+                while (tryInsert)
+                {
+                    try
+                    {
+                        _storageAdapter.Insert(TableName,
+                            new[] { ColumnChannelName, ColumnLogName },
+                            new List<object[]> {
+                            new object[] {channelName, logJsonString}
+                            });
+                        tryInsert = false;
+                    }
+                    catch (StorageFullException e)
+                    {
+                        var oldestLog = _storageAdapter.Select(TableName, ColumnChannelName, channelName, string.Empty, null, 1, new string[] { ColumnIdName });
+                        if (oldestLog != null && oldestLog.Count > 0)
+                        {
+                            _storageAdapter.Delete(TableName, ColumnIdName, oldestLog[0][0]);
+                        }
+                    }
+                }
             });
         }
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
@@ -176,18 +176,13 @@ namespace Microsoft.AppCenter.Storage
             return count;
         }
 
-        public long GetCurrentStorageSize()
-        {
-            return GetPageCount() * GetPageSize();
-        }
-
         public long GetMaxStorageSize()
         {
             try
             {
                 return GetMaxPageCount() * GetPageSize();
             }
-            catch (Exception e)
+            catch (StorageException)
             {
                 AppCenterLog.Error(AppCenterLog.LogTag, $"Could not get max storage size.");
                 return -1;
@@ -272,17 +267,7 @@ namespace Microsoft.AppCenter.Storage
                 args.AddRange(excludeValues);
             }
             var limitClause = limit != null ? $" LIMIT {limit}" : string.Empty;
-            var orderClause = string.Empty;
-            if (orderList != null && orderList.Length > 0)
-            {
-                orderClause = " ORDER BY";
-                var orderBuilder = new StringBuilder(orderClause);
-                foreach (var orderItem in orderList)
-                {
-                    orderBuilder.Append($" {orderItem},");
-                }
-                orderClause = $"{orderBuilder.ToString().TrimEnd(',')} ASC";
-            }
+            var orderClause = orderList != null && orderList.Length > 0 ? $" ORDER BY {string.Join(",", orderList)} ASC" : string.Empty;
             var query = $"SELECT * FROM {tableName} WHERE {whereClause}{orderClause}{limitClause};";
             return ExecuteSelectionSqlQuery(query, args);
         }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using SQLitePCL;
 
 namespace Microsoft.AppCenter.Storage
@@ -175,6 +176,19 @@ namespace Microsoft.AppCenter.Storage
             return count;
         }
 
+        public long GetMaxStorageSize()
+        {
+            try
+            {
+                return GetMaxPageCount() * GetPageSize();
+            }
+            catch (Exception e)
+            {
+                AppCenterLog.Error(AppCenterLog.LogTag, $"Could not get max storage size.");
+                return -1;
+            }
+        }
+
         public bool SetMaxStorageSize(long sizeInBytes)
         {
             bool success;
@@ -243,7 +257,7 @@ namespace Microsoft.AppCenter.Storage
             return (int)count;
         }
 
-        public IList<object[]> Select(string tableName, string columnName, object value, string excludeColumnName, object[] excludeValues, int? limit = null)
+        public IList<object[]> Select(string tableName, string columnName, object value, string excludeColumnName, object[] excludeValues, int? limit = null, string[] orderList = null)
         {
             var whereClause = $"{columnName} = ?";
             var args = new List<object> { value };
@@ -253,7 +267,18 @@ namespace Microsoft.AppCenter.Storage
                 args.AddRange(excludeValues);
             }
             var limitClause = limit != null ? $" LIMIT {limit}" : string.Empty;
-            var query = $"SELECT * FROM {tableName} WHERE {whereClause}{limitClause};";
+            var orderClause = string.Empty;
+            if (orderList != null && orderList.Length > 0)
+            {
+                orderClause = " ORDER BY";
+                StringBuilder orderBuilder = new StringBuilder(orderClause);
+                foreach (var orderItem in orderList)
+                {
+                    orderBuilder.Append($" {orderItem},");
+                }
+                orderClause = $"{orderBuilder.ToString().TrimEnd(',')} ASC";
+            }
+            var query = $"SELECT * FROM {tableName} WHERE {whereClause}{orderClause}{limitClause};";
             return ExecuteSelectionSqlQuery(query, args);
         }
 
@@ -276,11 +301,16 @@ namespace Microsoft.AppCenter.Storage
         {
             var errorMessage = raw.sqlite3_errmsg(_db).utf8_to_string();
             var exceptionMessage = $"{message}, result={result}\n\t{errorMessage}";
-            if (result == raw.SQLITE_CORRUPT || result == raw.SQLITE_NOTADB)
+            switch(result)
             {
-                return new StorageCorruptedException(exceptionMessage);
+                case raw.SQLITE_CORRUPT:
+                case raw.SQLITE_NOTADB:
+                    return new StorageCorruptedException(exceptionMessage);
+                case raw.SQLITE_FULL:
+                    return new StorageFullException(exceptionMessage);
+                default:
+                    return new StorageException(exceptionMessage);
             }
-            return new StorageException(exceptionMessage);
         }
 
         private static string BuildBindingMask(int amount)

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageAdapter.cs
@@ -176,6 +176,11 @@ namespace Microsoft.AppCenter.Storage
             return count;
         }
 
+        public long GetCurrentStorageSize()
+        {
+            return GetPageCount() * GetPageSize();
+        }
+
         public long GetMaxStorageSize()
         {
             try
@@ -271,7 +276,7 @@ namespace Microsoft.AppCenter.Storage
             if (orderList != null && orderList.Length > 0)
             {
                 orderClause = " ORDER BY";
-                StringBuilder orderBuilder = new StringBuilder(orderClause);
+                var orderBuilder = new StringBuilder(orderClause);
                 foreach (var orderItem in orderList)
                 {
                     orderBuilder.Append($" {orderItem},");

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageFullException.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/StorageFullException.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.AppCenter.Storage
+{
+    internal class StorageFullException : StorageException
+    {
+        private const string DefaultMessage = "The database is full.";
+
+        public StorageFullException() : base(DefaultMessage) { }
+
+        public StorageFullException(string message) : base(message) { }
+    }
+}


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

When the database is full the oldest logs will be deleted on insert.

## Related PRs or issues

[AB#83867](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83867)
