### PR TITLE
Add fallback logic when calling incompatible API in self-contained app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.1.1 (Under development)
 
+### AppCenter
+
+* **[Fix]** Fix SDK not sending events when application is packed to self-contained single-file executable.
+
 ___
 
 ## Version 4.1.0

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -189,7 +189,14 @@ namespace Microsoft.AppCenter.Utils
                 var entryAssembly = Assembly.GetEntryAssembly();
                 if (entryAssembly != null)
                 {
-                    var fileVersionInfo = FileVersionInfo.GetVersionInfo(entryAssembly.Location);
+                    var assemblyLocation = entryAssembly.Location;
+                    if (string.IsNullOrWhiteSpace(assemblyLocation))
+                    {
+                        // This is a fix for single file (self-contained publish) api incompatibility in runtime.
+                        // Read at https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file#api-incompatibility
+                        assemblyLocation = Environment.GetCommandLineArgs()[0];
+                    }
+                    var fileVersionInfo = FileVersionInfo.GetVersionInfo(assemblyLocation);
                     return fileVersionInfo.FileVersion;
                 }
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes usage of incompatible API in cases when application is published as single-file self-contained executable.

## Related PRs or issues

[AB#84318](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/84318)
#1483 