### PR TITLE
Fix linking frameworks for Distribute iOS

### DIFF
--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/Microsoft.AppCenter.Distribute.iOS.Bindings.csproj
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/Microsoft.AppCenter.Distribute.iOS.Bindings.csproj
@@ -61,7 +61,7 @@
       <Kind>Static</Kind>
       <SmartLink>False</SmartLink>
       <ForceLoad>True</ForceLoad>
-      <WeakFrameworks>SafariServices</WeakFrameworks>
+      <WeakFrameworks>SafariServices AuthenticationServices</WeakFrameworks>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix `error MT5211: Native linking failed, undefined Objective-C class: ASWebAuthenticationSession. The symbol '_OBJC_CLASS_$_ASWebAuthenticationSession' could not be found in any of the libraries or frameworks linked with your application.`

## Related PRs or issues

[AB#85781](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/85781)