### PR TITLE
[Windows] Fix Infinite StorageFullException when old logs cannot be purged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### App Center Crashes
 
+#### Windows
+
+* **[Fix]** Fix infinite loop when old logs cannot be purged by a new one with a different channel name in a case when the storage is full.
+
 #### WPF/WinForms
 
 * **[Fix]** Add obfuscation for username value in the stack trace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 * **[Feature]** Add a `AppCenter.IsNetworkRequestsAllowed` API to block any network requests without disabling the SDK.
 
-### App Center Crashes
-
 #### Windows
 
 * **[Fix]** Fix infinite loop when old logs cannot be purged by a new one with a different channel name in a case when the storage is full.
+
+### App Center Crashes
 
 #### WPF/WinForms
 
@@ -20,7 +20,7 @@
 
 #### Android
 
-- **[Fix]** Fix replacement of Distribute dependencies for publishing in Google Play.
+* **[Fix]** Fix replacement of Distribute dependencies for publishing in Google Play.
 
 ___
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Storage/Storage.cs
@@ -115,6 +115,10 @@ namespace Microsoft.AppCenter.Storage
                         {
                             _storageAdapter.Delete(TableName, ColumnIdName, oldestLog[0][0]);
                         }
+                        else
+                        {
+                            throw new StorageException("Failed to add a new log. Storage is full and old logs cannot be purged.");
+                        }
                     }
                 }
             });

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -467,7 +467,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
             var firstLog = initialLogs[0];
             var secondLog = initialLogs[1];
 
-            // Create a new log. Vverify that new log was added and old was deleted.
+            // Create a new log. Verify that new log was added and old was deleted.
             var newLog = TestLog.CreateTestLog();
             await _storage.PutLog(StorageTestChannelName, newLog);
             var retrievedLogs = new List<Log>();
@@ -501,7 +501,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
             await _storage.GetLogsAsync(StorageTestChannelName, int.MaxValue, initialLogs);
 
             // Try to add a new log with another channel name to storage.
-            // Vverify that StorageException is thrown.
+            // Verify that StorageException is thrown.
             var newLog = TestLog.CreateTestLog();
             try
             {

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -485,7 +485,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
         [TestMethod]
         public async Task SaveLogDoesntPurgesOldLogsWhenStorageIsFullOfDifferentKindOfLogs()
         {
-            // Prepare constants
+            // Prepare constants.
             var anotherChannelName = "anotherChannelName";
 
             // Set storage max size.
@@ -496,7 +496,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
             // Fill databse with logs.
             await FillDatabaseWithLogs(capacity);
 
-            // Get stored collection
+            // Get stored collection.
             var initialLogs = new List<Log>();
             await _storage.GetLogsAsync(StorageTestChannelName, int.MaxValue, initialLogs);
 
@@ -520,7 +520,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
 
             // Verify that new log was not added.
             await _storage.GetLogsAsync(anotherChannelName, int.MaxValue, retrievedLogs);
-            Assert.IsTrue(retrievedLogs.Count == 0);
+            Assert.AreEqual(0, retrievedLogs.Count)
         }
 
         /// <summary>
@@ -565,7 +565,6 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
         {
             var putLogTasks = new Task[n];
             var addedLogs = new List<TestLog>();
-            
             for (var i = 0; i < n; ++i)
             {
                 var testLog = TestLog.CreateTestLog();

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -480,7 +480,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
 
         /// <summary>
         /// Verify that Storage doesn't loop infinitely if old logs cannot be purged.
-        /// Verify that Storage doesn't save a new log in case it cannot purge older ones.
+        /// And doesn't save a new log in case it cannot purge older ones.
         /// </summary>
         [TestMethod]
         public async Task SaveLogDoesntPurgesOldLogsWhenStorageIsFullOfDifferentKindOfLogs()

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -521,7 +521,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
 
             // Verify that new log was not added.
             await _storage.GetLogsAsync(anotherChannelName, int.MaxValue, retrievedLogs);
-            Assert.AreEqual(0, retrievedLogs.Count)
+            Assert.AreEqual(0, retrievedLogs.Count);
         }
 
         /// <summary>

--- a/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Storage/StorageTest.cs
@@ -506,6 +506,7 @@ namespace Microsoft.AppCenter.Test.Windows.Storage
             try
             {
                 await _storage.PutLog(anotherChannelName, newLog);
+                Assert.Fail("It should be failed.");
             }
             catch (StorageException e)
             {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes infinite loop when trying to add a new log to storage which is full of logs with a different channel name. Storage can only remove logs from the channel of a newly adding log.

## Related PRs or issues

[AB#86765](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/86765)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1527
