### PR TITLE
fix issue with TLS1.3 and systemdefault flag

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +16,11 @@ namespace Microsoft.AppCenter.Ingestion.Http
     {
         internal const string ContentTypeValue = "application/json; charset=utf-8";
 
+        // used by the windows platform to override and force tls1.2
+        internal static readonly HttpMessageHandler HttpMessageHandlerOverride;
+
         private HttpClient _httpClient;
+
         private readonly object _lockObject = new object();
 
         // Exception codes (HResults) involving poor network connectivity:
@@ -46,7 +51,8 @@ namespace Microsoft.AppCenter.Ingestion.Http
                     {
                         return _httpClient;
                     }
-                    _httpClient = new HttpClient();
+
+                    _httpClient = HttpMessageHandlerOverride != null ? new HttpClient(HttpMessageHandlerOverride) : new HttpClient();
                     return _httpClient;
                 }
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Ingestion/Http/HttpNetworkAdapter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AppCenter.Ingestion.Http
         internal const string ContentTypeValue = "application/json; charset=utf-8";
 
         // used by the windows platform to override and force tls1.2
-        internal static readonly HttpMessageHandler HttpMessageHandlerOverride;
+        internal static readonly Func<HttpMessageHandler> HttpMessageHandlerOverride;
 
         private HttpClient _httpClient;
 
@@ -52,7 +52,7 @@ namespace Microsoft.AppCenter.Ingestion.Http
                         return _httpClient;
                     }
 
-                    _httpClient = HttpMessageHandlerOverride != null ? new HttpClient(HttpMessageHandlerOverride) : new HttpClient();
+                    _httpClient = HttpMessageHandlerOverride != null ? new HttpClient(HttpMessageHandlerOverride()) : new HttpClient();
                     return _httpClient;
                 }
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net;
+using System.Net.Http;
+using System.Security.Authentication;
 
 namespace Microsoft.AppCenter.Ingestion.Http
 {
@@ -11,17 +12,10 @@ namespace Microsoft.AppCenter.Ingestion.Http
         // Static initializer specific to windows desktop platforms.
         static HttpNetworkAdapter()
         {
-            EnableTls12();
-        }
-
-        internal static void EnableTls12()
-        {
-            // ReSharper disable once InvertIf
-            if ((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls12) != SecurityProtocolType.Tls12)
+            HttpMessageHandlerOverride = new HttpClientHandler
             {
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
-                AppCenterLog.Debug(AppCenterLog.LogTag, "Enabled TLS 1.2 explicitly as it was disabled.");
-            }
+                SslProtocols = SslProtocols.Tls12
+            };
         }
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Ingestion/Http/HttpNetworkAdapter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AppCenter.Ingestion.Http
         // Static initializer specific to windows desktop platforms.
         static HttpNetworkAdapter()
         {
-            HttpMessageHandlerOverride = new HttpClientHandler
+            HttpMessageHandlerOverride = () => new HttpClientHandler
             {
                 SslProtocols = SslProtocols.Tls12
             };

--- a/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpNetworkAdapterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpNetworkAdapterTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AppCenter.Test.Windows.Ingestion.Http
             Assert.AreEqual(SslProtocols.Tls12, httpClientHandler.SslProtocols);
 
             // Just check no side effect.
-            Assert.AreEqual(SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12, ServicePointManager.SecurityProtocol);
+            Assert.AreEqual(SecurityProtocolType.SystemDefault, ServicePointManager.SecurityProtocol);
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpNetworkAdapterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpNetworkAdapterTest.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
+using System.Security.Authentication;
 using Microsoft.AppCenter.Ingestion.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -35,6 +37,21 @@ namespace Microsoft.AppCenter.Test.Windows.Ingestion.Http
             Assert.IsTrue(request.Headers.Contains(IngestionHttp.AppSecret));
             Assert.IsTrue(request.Headers.Contains(IngestionHttp.InstallId));
             Assert.IsInstanceOfType(request.Content, typeof(StringContent));
+        }
+
+        [TestMethod]
+        public void EnableTls12WhenServicePointManagerSetToSystemDefault()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault;
+
+            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride as HttpClientHandler;
+
+            Assert.IsNotNull(httpClientHandler);
+
+            Assert.AreEqual(SslProtocols.Tls12, httpClientHandler.SslProtocols);
+
+            // Just check no side effect.
+            Assert.AreEqual(SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12, ServicePointManager.SecurityProtocol);
         }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpNetworkAdapterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Ingestion/Http/HttpNetworkAdapterTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AppCenter.Test.Windows.Ingestion.Http
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault;
 
-            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride as HttpClientHandler;
+            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride() as HttpClientHandler;
 
             Assert.IsNotNull(httpClientHandler);
 

--- a/Tests/Microsoft.AppCenter.Test.Windows/Microsoft.AppCenter.Test.Windows.csproj
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Microsoft.AppCenter.Test.Windows.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.AppCenter.Test.Windows</RootNamespace>
     <AssemblyName>Microsoft.AppCenter.Test.Windows</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -18,6 +18,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Channel\ChannelGroupTest.cs" />

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Ingestion/Http/HttpNetworkAdapterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Ingestion/Http/HttpNetworkAdapterTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Ingestion.Http
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11;
 
-            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride as HttpClientHandler;
+            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride() as HttpClientHandler;
 
             Assert.NotNull(httpClientHandler);
 
@@ -28,7 +28,7 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Ingestion.Http
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
-            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride as HttpClientHandler;
+            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride() as HttpClientHandler;
 
             Assert.NotNull(httpClientHandler);
 

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Ingestion/Http/HttpNetworkAdapterTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.Shared/Ingestion/Http/HttpNetworkAdapterTest.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AppCenter.Ingestion.Http;
 using System.Net;
+using System.Net.Http;
+using System.Security.Authentication;
 using Xunit;
 
 namespace Microsoft.AppCenter.Test.WindowsDesktop.Ingestion.Http
@@ -10,17 +12,27 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Ingestion.Http
         public void EnableTls12WhenDisabled()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11;
-            HttpNetworkAdapter.EnableTls12();
+
+            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride as HttpClientHandler;
+
+            Assert.NotNull(httpClientHandler);
 
             // Check protocol was added, not the whole value overridden.
-            Assert.Equal(SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12, ServicePointManager.SecurityProtocol);
+            Assert.Equal(SslProtocols.Tls12, httpClientHandler.SslProtocols);
+
+            Assert.Equal(ServicePointManager.SecurityProtocol, SecurityProtocolType.Tls | SecurityProtocolType.Tls11);
         }
 
         [Fact]
         public void EnableTls12WhenAlreadyEnabled()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
-            HttpNetworkAdapter.EnableTls12();
+
+            var httpClientHandler = HttpNetworkAdapter.HttpMessageHandlerOverride as HttpClientHandler;
+
+            Assert.NotNull(httpClientHandler);
+
+            Assert.Equal(SslProtocols.Tls12, httpClientHandler.SslProtocols);
 
             // Just check no side effect.
             Assert.Equal(SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12, ServicePointManager.SecurityProtocol);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Proof of concept on fixing #1531 - happy to assist \ adjust. Removes use of ServicePointManager and uses a Http Client Handler as recommended on https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager?view=net-5.0

Many Thanks :)

## Related PRs or issues
#1531

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
unable to run the tests as the "strong name" piece fails in the build