### PR TITLE
[Windows] Check pending logs on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * **[Feature]** Add support for platform `WinUI in Desktop`. The target version of `WinUI` apps should be `net5.0-windows10.0.17763.0` or higher.
 * **[Fix]** Update `Newtonsoft.Json` dependency to version `13.0.1`.
+* **[Fix]** Check and send pending handled error logs on start.
 
 ___
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -71,6 +71,7 @@ namespace Microsoft.AppCenter.Channel
                     _pendingLogCount = task.Result;
                 }
                 lockHolder.Dispose();
+                CheckPendingLogs(_mutex.State);
             });
         }
 

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
@@ -500,7 +500,7 @@ namespace Microsoft.AppCenter.Test.Channel
             _mockIngestion.Setup(ingestion => ingestion.IsEnabled).Returns(true);
             SetChannelWithTimeSpan(TimeSpan.Zero);
 
-            // Enqueue some log and and do not complete it
+            // Enqueue some log and do not complete it
             var call = new ServiceCall();
             _mockIngestion
                 .Setup(ingestion => ingestion.Call(
@@ -533,7 +533,7 @@ namespace Microsoft.AppCenter.Test.Channel
             _mockIngestion.Setup(ingestion => ingestion.IsEnabled).Returns(true);
             SetChannelWithTimeSpan(TimeSpan.Zero);
 
-            // Enqueue some log and and do not complete it
+            // Enqueue some log and do not complete it
             var call = new ServiceCall();
             _mockIngestion
                 .Setup(ingestion => ingestion.Call(
@@ -714,19 +714,19 @@ namespace Microsoft.AppCenter.Test.Channel
         [TestMethod]
         public async Task CheckPendingLogsOnStart()
         {
-            // Prepare data.
             var log = new TestLog();
+            _mockIngestion.Setup(ingestion => ingestion.IsEnabled).Returns(true);
             var storage = new Mock<IStorage>();
             storage.Setup(s => s.GetLogsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<List<Log>>()))
                     .Callback((string channelName, int limit, List<Log> logs) => logs.Add(log))
                     .Returns(() => Task.FromResult("test-batch-id"));
             storage.Setup(s => s.CountLogsAsync(ChannelName)).Returns(() => Task.FromResult(1));
             
-            SetupEventCallbacks();
-
+            // Prepare data.
             var appSecret = Guid.NewGuid().ToString();
-            Channel channel = new Channel(ChannelName, MaxLogsPerBatch, new TimeSpan(), MaxParallelBatches,
+            _channel = new Channel(ChannelName, MaxLogsPerBatch, new TimeSpan(), MaxParallelBatches,
                 appSecret, _mockIngestion.Object, storage.Object);
+            SetupEventCallbacks();
 
             // Verify that checkPendingLogs was called and logs were sent.
             await Task.Delay(1000);


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Analytics and Core modules send initial events on start and it triggers checking pending logs. In case of Crashes module, we don't send any logs on start and thus pending logs are not processed.
This change will make sure all channels check pending logs on start, including Crashes.

## Related PRs or issues

[AB#87546](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/87546)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1547/
