### PR TITLE
[uwp-puppet] Remove redundant Json dep

### DIFF
--- a/Apps/Contoso.UWP.Puppet/Contoso.UWP.Puppet.csproj
+++ b/Apps/Contoso.UWP.Puppet/Contoso.UWP.Puppet.csproj
@@ -170,9 +170,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.2</Version>
-    </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>


### PR DESCRIPTION
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

UWP puppet references to `Newtonsoft.Json` of version 12 and it conflicts with version used by the SDK, which is 13.
Since the puppet project doesn't use the `Newtonsoft.Json` library, a simple removal of the dependency fixes the issue.