### PR TITLE
Fix DeviceInformationHelper for net5.0-windows10 unpackaged apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **[Breaking change]** Remove `AppCenter.SetCustomProperties` API.
 * **[Fix]** Fix App Center SDK compatibility with projects targeting .NETCore3.0 and higher.
+* **[Fix]** Fix App Center SDK compatibility with unpackaged projects targeting .NET 5.0 and higher on Windows 10.
 
 ___
 

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.NetCore/Microsoft.AppCenter.Test.WindowsDesktop.NetCore.csproj
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.NetCore/Microsoft.AppCenter.Test.WindowsDesktop.NetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;net5.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.AppCenter.Test.WindowsDesktop</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/Tests/Microsoft.AppCenter.Test.WindowsDesktop.NetCore/Utils/DeviceInformationHelperTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.WindowsDesktop.NetCore/Utils/DeviceInformationHelperTest.cs
@@ -18,7 +18,11 @@ namespace Microsoft.AppCenter.Test.WindowsDesktop.Utils
         public void VerifySdkName()
         {
             var device = Task.Run(() => new DeviceInformationHelper().GetDeviceInformationAsync()).Result;
+#if NETCOREAPP3_0
             Assert.Equal("appcenter.wpf.netcore", device.SdkName);
+#else
+            Assert.Equal("appcenter.wpf", device.SdkName);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

`DeviceInformationHelper` currently assumes that apps targeting net5.0-windows with a target framework version (e.g. `net5.0-windows-10.0.17763.0`) are deployed with an MSIX package, but this is not necessarily the case. When executed outside of a packaged app, `Package.Current` throws an `InvalidOperationException` which causes event collection to fail.

## Related PRs or issues

Fixes #1589

## Misc

I wasn't able to run all of the tests due to some errors with code signing and test runner packages, but I've manually tested the changes with external projects.