### PR TITLE
Fix deadlock while checking pending logs on SDK start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * **[Fix]** Fix App Center SDK compatibility with project targets .NET Framework and .NET Core.
 * **[Fix]** Fix crash during getting device information when WMI service is disabled.
-* **[Fix]** Fix a deadlock on app start caused by an improper StatefulMutex usage. The issue was observed on Windows Server OS.
+* **[Fix]** Fix a deadlock after the application start caused by improper `StatefulMutex` usage on the Windows Server OS.
 
 #### Xamarin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * **[Fix]** Fix App Center SDK compatibility with project targets .NET Framework and .NET Core.
 * **[Fix]** Fix crash during getting device information when WMI service is disabled.
+* **[Fix]** Fix a deadlock on app start caused by an improper StatefulMutex usage. The issue was observed on Windows Server OS.
 
 #### Xamarin
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -71,7 +71,6 @@ namespace Microsoft.AppCenter.Channel
                     _pendingLogCount = task.Result;
                 }
                 lockHolder.Dispose();
-                CheckPendingLogs(_mutex.State);
             });
         }
 
@@ -584,6 +583,11 @@ namespace Microsoft.AppCenter.Channel
             {
                 Suspend(_mutex.State, false, new CancellationException(), false);
             }
+        }
+
+        public void CheckPendingLogs()
+        {
+            CheckPendingLogs(_mutex.State);
         }
 
         private void CheckPendingLogs(State state)

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -628,10 +628,9 @@ namespace Microsoft.AppCenter.Channel
         }
 
         /// <summary>
-        /// Enable or disable network requests.
-        /// Data will be saved in database while network requests are disabled. 
+        /// Set network request allowed. If true check pending logs, suspend sending logs otherwise.
         /// </summary>
-        /// <param name="isAllowed">Allow network requests if false, disallow otherwise. True by default.</param>
+        /// <param name="isAllowed">True if network request allowed, false otherwise.</param>
         public void SetNetworkRequestAllowed(bool isAllowed)
         {
             if (isAllowed)
@@ -645,7 +644,7 @@ namespace Microsoft.AppCenter.Channel
         }
 
         /// <summary>
-        /// Check pending logs and trigger ingestion if any.
+        /// Check if there are any pending logs in database and rigger ingestion if such logs are found.
         /// </summary>
         public void CheckPendingLogs()
         {

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -228,7 +228,7 @@ namespace Microsoft.AppCenter.Channel
                 }
                 if (enabled)
                 {
-                    CheckPendingLogs(state);
+                    CheckPendingLogsInternal(state);
                     return;
                 }
                 AppCenterLog.Warn(AppCenterLog.LogTag, "Channel is temporarily disabled; log was saved to disk");
@@ -299,7 +299,7 @@ namespace Microsoft.AppCenter.Channel
             {
                 AppCenterLog.Warn(AppCenterLog.LogTag, "The resume operation has been canceled");
             }
-            CheckPendingLogs(state);
+            CheckPendingLogsInternal(state);
         }
 
         /// <summary>
@@ -467,7 +467,7 @@ namespace Microsoft.AppCenter.Channel
                         _calls.Add(ingestionCall);
                     }
                     ingestionCall.ContinueWith(call => HandleSendingResult(state, batchId, call));
-                    CheckPendingLogs(state);
+                    CheckPendingLogsInternal(state);
                 }
                 catch (StorageException)
                 {
@@ -544,7 +544,7 @@ namespace Microsoft.AppCenter.Channel
             {
                 AppCenterLog.Warn(AppCenterLog.LogTag, $"Could not delete logs for batch {batchId}", e);
             }
-            CheckPendingLogs(state);
+            CheckPendingLogsInternal(state);
         }
 
         private void HandleSendingFailure(State state, string batchId, Exception exception)
@@ -585,7 +585,7 @@ namespace Microsoft.AppCenter.Channel
                 AppCenterLog.Info(AppCenterLog.LogTag, "App Center is in offline mode.");
                 return;
             }
-            AppCenterLog.Debug(AppCenterLog.LogTag, $"CheckPendingLogs({Name}) pending log count: {_pendingLogCount}");
+            AppCenterLog.Debug(AppCenterLog.LogTag, $"CheckPendingLogsInternal({Name}) pending log count: {_pendingLogCount}");
             using (_mutex.GetLock())
             {
                 if (_pendingLogCount >= _maxLogsPerBatch)

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/Channel.cs
@@ -573,24 +573,7 @@ namespace Microsoft.AppCenter.Channel
             }
         }
 
-        public void SetNetworkRequestAllowed(bool isAllowed)
-        {
-            if (isAllowed)
-            {
-                Resume(_mutex.State, false);
-            }
-            else
-            {
-                Suspend(_mutex.State, false, new CancellationException(), false);
-            }
-        }
-
-        public void CheckPendingLogs()
-        {
-            CheckPendingLogs(_mutex.State);
-        }
-
-        private void CheckPendingLogs(State state)
+        private void CheckPendingLogsInternal(State state)
         {
             if (!_enabled)
             {
@@ -642,6 +625,31 @@ namespace Microsoft.AppCenter.Channel
                     });
                 }
             }
+        }
+
+        /// <summary>
+        /// Enable or disable network requests.
+        /// Data will be saved in database while network requests are disabled. 
+        /// </summary>
+        /// <param name="isAllowed">Allow network requests if false, disallow otherwise. True by default.</param>
+        public void SetNetworkRequestAllowed(bool isAllowed)
+        {
+            if (isAllowed)
+            {
+                Resume(_mutex.State, false);
+            }
+            else
+            {
+                Suspend(_mutex.State, false, new CancellationException(), false);
+            }
+        }
+
+        /// <summary>
+        /// Check pending logs and trigger ingestion if any.
+        /// </summary>
+        public void CheckPendingLogs()
+        {
+            CheckPendingLogsInternal(_mutex.State);
         }
 
         /// <summary>

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/ChannelGroup.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/ChannelGroup.cs
@@ -94,6 +94,7 @@ namespace Microsoft.AppCenter.Channel
                     // The benefit of throwing an exception in this case is debatable. Might make sense to allow this.
                     throw new AppCenterException("Attempted to add duplicate channel to group");
                 }
+                channel.CheckPendingLogs();
                 channel.EnqueuingLog += AnyChannelEnqueuingLog;
                 channel.FilteringLog += AnyChannelFilteringLog;
                 channel.SendingLog += AnyChannelSendingLog;
@@ -119,6 +120,14 @@ namespace Microsoft.AppCenter.Channel
             foreach (var channel in _channels)
             {
                 channel.SetNetworkRequestAllowed(isAllowed);
+            }
+        }
+
+        public void CheckPendingLogs()
+        {
+            foreach (var channel in _channels)
+            {
+                channel.CheckPendingLogs();
             }
         }
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/ChannelGroup.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/ChannelGroup.cs
@@ -123,14 +123,6 @@ namespace Microsoft.AppCenter.Channel
             }
         }
 
-        public void CheckPendingLogs()
-        {
-            foreach (var channel in _channels)
-            {
-                channel.CheckPendingLogs();
-            }
-        }
-
         public Task<bool> SetMaxStorageSizeAsync(long sizeInBytes)
         {
             ThrowIfDisposed();

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannel.cs
@@ -52,5 +52,11 @@ namespace Microsoft.AppCenter.Channel
         /// </summary>
         /// <param name="isAllowed">True if network request allowed, false otherwise.</param>
         void SetNetworkRequestAllowed(bool isAllowed);
+
+        /// <summary>
+        /// Check if there are any pending logs in database.
+        /// Trigger ingestion if logs are found.
+        /// </summary>
+        void CheckPendingLogs();
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannel.cs
@@ -54,8 +54,7 @@ namespace Microsoft.AppCenter.Channel
         void SetNetworkRequestAllowed(bool isAllowed);
 
         /// <summary>
-        /// Check if there are any pending logs in database.
-        /// Trigger ingestion if logs are found.
+        /// Check if there are any pending logs in database and rigger ingestion if such logs are found.
         /// </summary>
         void CheckPendingLogs();
     }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannel.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannel.cs
@@ -52,10 +52,5 @@ namespace Microsoft.AppCenter.Channel
         /// </summary>
         /// <param name="isAllowed">True if network request allowed, false otherwise.</param>
         void SetNetworkRequestAllowed(bool isAllowed);
-
-        /// <summary>
-        /// Check if there are any pending logs in database and rigger ingestion if such logs are found.
-        /// </summary>
-        void CheckPendingLogs();
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannelUnit.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Windows.Shared/Channel/IChannelUnit.cs
@@ -16,5 +16,10 @@ namespace Microsoft.AppCenter.Channel
         /// </summary>
         /// <param name="log"></param>
         Task EnqueueAsync(Log log);
+
+        /// <summary>
+        /// Check if there are any pending logs in database and rigger ingestion if such logs are found.
+        /// </summary>
+        void CheckPendingLogs();
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
@@ -213,7 +213,7 @@ namespace Microsoft.AppCenter.Test.Channel
         }
 
         /// <summary>
-        /// Veriy that all channels are disabled after channel group disabling
+        /// Veriy that all channels are disabled after channel group disabling.
         /// </summary>
         [TestMethod]
         public async Task TestShutdownChannelGroup()
@@ -228,6 +228,9 @@ namespace Microsoft.AppCenter.Test.Channel
             _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Once);
         }
 
+        /// <summary>
+        /// Verify that a channel sends pending logs after it is added to a channel group.
+        /// </summary>
         [TestMethod]
         public async Task TestPendingLogsAreSentOnAddChannel()
         {
@@ -248,17 +251,20 @@ namespace Microsoft.AppCenter.Test.Channel
             // Wait when tasks will be finalized.
             await Task.Delay(500);
 
-            //Verify channel sends pending logs.
+            // Verify channel sends pending logs.
             _mockIngestion.Verify(ingestion => ingestion.Call(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<IList<Log>>()), Times.Once);
         }
 
+        /// <summary>
+        /// Verify that a channel group invokes check pending logs on a channel after adding it.
+        /// </summary>
         [TestMethod]
-        public async Task TestCheckPendingLogsOnAddChannel()
+        public void TestCheckPendingLogsOnAddChannel()
         {
             var channelMock = new Mock<IChannelUnit>();
             _channelGroup.AddChannel(channelMock.Object);
 
-            //Verify channel is trying to check pending logs.
+            // Verify the channel is trying to check pending logs.
             channelMock.Verify(channel => channel.CheckPendingLogs(), Times.Once);
         }
     }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
@@ -229,15 +229,13 @@ namespace Microsoft.AppCenter.Test.Channel
         }
 
         /// <summary>
-        /// Verify that channel group's sending log event fires when appropriate
+        /// Verify that channel group invokes check pending logs on channel after adding it.
         /// </summary>
         [TestMethod]
         public void TestCheckPendingLogsOnAddChannel()
         {
-            var fired = false;
             var mockChannel = new Mock<IChannelUnit>();
             _channelGroup.AddChannel(mockChannel.Object);
-
             mockChannel.Verify(channel => channel.CheckPendingLogs(), Times.Once);
         }
     }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
@@ -259,7 +259,7 @@ namespace Microsoft.AppCenter.Test.Channel
         /// Verify that a channel group invokes check pending logs on a channel after adding it.
         /// </summary>
         [TestMethod]
-        public void TestCheckPendingLogsOnAddChannel()
+        public void TestCheckPendingLogsAfterAddChannel()
         {
             var channelMock = new Mock<IChannelUnit>();
             _channelGroup.AddChannel(channelMock.Object);

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelGroupTest.cs
@@ -227,5 +227,18 @@ namespace Microsoft.AppCenter.Test.Channel
             Assert.IsFalse(addedChannel.IsEnabled);
             _mockIngestion.Verify(ingestion => ingestion.Close(), Times.Once);
         }
+
+        /// <summary>
+        /// Verify that channel group's sending log event fires when appropriate
+        /// </summary>
+        [TestMethod]
+        public void TestCheckPendingLogsOnAddChannel()
+        {
+            var fired = false;
+            var mockChannel = new Mock<IChannelUnit>();
+            _channelGroup.AddChannel(mockChannel.Object);
+
+            mockChannel.Verify(channel => channel.CheckPendingLogs(), Times.Once);
+        }
     }
 }

--- a/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
+++ b/Tests/Microsoft.AppCenter.Test.Windows/Channel/ChannelTest.cs
@@ -711,28 +711,6 @@ namespace Microsoft.AppCenter.Test.Channel
             }
         }
 
-        [TestMethod]
-        public async Task CheckPendingLogsOnStart()
-        {
-            var log = new TestLog();
-            _mockIngestion.Setup(ingestion => ingestion.IsEnabled).Returns(true);
-            var storage = new Mock<IStorage>();
-            storage.Setup(s => s.GetLogsAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<List<Log>>()))
-                    .Callback((string channelName, int limit, List<Log> logs) => logs.Add(log))
-                    .Returns(() => Task.FromResult("test-batch-id"));
-            storage.Setup(s => s.CountLogsAsync(ChannelName)).Returns(() => Task.FromResult(1));
-            
-            // Prepare data.
-            var appSecret = Guid.NewGuid().ToString();
-            _channel = new Channel(ChannelName, MaxLogsPerBatch, new TimeSpan(), MaxParallelBatches,
-                appSecret, _mockIngestion.Object, storage.Object);
-            SetupEventCallbacks();
-
-            // Verify that checkPendingLogs was called and logs were sent.
-            await Task.Delay(1000);
-            VerifySendingLog(1);
-        }
-
         private void SetChannelWithTimeSpan(TimeSpan timeSpan)
         {
             SetChannelWithTimeSpanAndIngestion(timeSpan, _mockIngestion.Object);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This issue was found when running on Windows Server machine.
Channel was stuck in dead lock while trying to check Pending logs
on start and at the same time trying to perform other async operations.

Removing checkPendingLogs from Channel's ctor and moving it
to ChannelGroup on adding a channel solves the problem. This solution
is also consistent with Android SDK implementation.

## Related PRs or issues

[AB#89546](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/89546)
