### PR TITLE
[UWP] Fix crash in Crashes.TrackError if image dictionary is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 * **[Feature]**  Add support target framework `net5.0-windows10.0.17763.0` or higher for non-WinUI applications.
 
+### App Center Crashes
+
+#### UWP
+
+* **[Fix]** Fix crash when use `Crashes.TrackError` API where exception has frames with empty native images.
+
+___
+
 ## Version 4.5.0
 
 ### App Center

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Utils/ErrorLogHelperPart.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Utils/ErrorLogHelperPart.cs
@@ -111,6 +111,12 @@ namespace Microsoft.AppCenter.Crashes.Utils
             using (var reader = new PEReader((byte*)imageBase.ToPointer(), imageSize, true))
             {
                 var debugdir = reader.ReadDebugDirectory();
+
+                // In some cases debugDir can be empty even though frame.GetNativeImageBase() returns a value.
+                if (debugdir.IsEmpty)
+                {
+                    return null;
+                }
                 var codeViewEntry = debugdir.First(entry => entry.Type == DebugDirectoryEntryType.CodeView);
 
                 // When attaching a debugger in release, it will break into MissingRuntimeArtifactException, just click continue as it is actually caught and recovered by the lib.

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Utils/ErrorLogHelperPart.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.UWP/Utils/ErrorLogHelperPart.cs
@@ -110,14 +110,14 @@ namespace Microsoft.AppCenter.Crashes.Utils
             var imageSize = GetImageSize(imageBase);
             using (var reader = new PEReader((byte*)imageBase.ToPointer(), imageSize, true))
             {
-                var debugdir = reader.ReadDebugDirectory();
+                var debugDir = reader.ReadDebugDirectory();
 
                 // In some cases debugDir can be empty even though frame.GetNativeImageBase() returns a value.
-                if (debugdir.IsEmpty)
+                if (debugDir.IsEmpty)
                 {
                     return null;
                 }
-                var codeViewEntry = debugdir.First(entry => entry.Type == DebugDirectoryEntryType.CodeView);
+                var codeViewEntry = debugDir.First(entry => entry.Type == DebugDirectoryEntryType.CodeView);
 
                 // When attaching a debugger in release, it will break into MissingRuntimeArtifactException, just click continue as it is actually caught and recovered by the lib.
                 var codeView = reader.ReadCodeViewDebugDirectoryData(codeViewEntry);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes a crash in Crashes.TrackError if native image dictionary is empty for some stack trace frame.

## Related PRs or issues

[AB#90915](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/90915)