### PR TITLE
Fix Xamarin.Mac native framework integration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,8 @@ jobs:
     #    uses a compiled language 
     
     - run: |
-        echo "Run Externals-iOS"
-        ./build.sh -target="Externals-iOS"
+        echo "Run Externals-Apple"
+        ./build.sh -target="Externals-Apple"
 
     - run: |
         echo "Build App Center For iOS"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,10 +43,12 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language 
-    
-    - run: |
-        echo "Run Externals-Apple"
-        ./build.sh -target="Externals-Apple"
+
+    steps:
+      - name: Run the Cake script
+        uses: cake-build/cake-action@v1
+        with:
+          target: Externals-Apple
 
     - run: |
         echo "Build App Center For iOS"

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/appcenter-post-clone.sh
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/appcenter-post-clone.sh
@@ -27,5 +27,5 @@ if [ -e $nugetFileName ]; then
 fi
 echo $contentValue >> $nugetFileName
 ./scripts/update-app-secrets.sh PROD
-./build.sh -t=externals-ios
+./build.sh -t=Externals-Apple
 popd

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/appcenter-post-clone.sh
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.iOS/appcenter-post-clone.sh
@@ -27,5 +27,5 @@ if [ -e $nugetFileName ]; then
 fi
 echo $contentValue >> $nugetFileName
 ./scripts/update-app-secrets.sh
-./build.sh -t=externals-ios
+./build.sh -t=Externals-Apple
 popd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * **[Feature]**  Add support target framework `net5.0-windows10.0.17763.0` or higher for non-WinUI applications.
 
+#### macOS 
+
+* **[Fix]** Fix "Malformed Framework" error when submitting to App Store.
+
 ### App Center Crashes
 
 #### UWP

--- a/SDK/AppCenter/Microsoft.AppCenter.MacOS.Bindings/Microsoft.AppCenter.MacOS.Bindings.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.MacOS.Bindings/Microsoft.AppCenter.MacOS.Bindings.csproj
@@ -79,7 +79,7 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\macos\AppCenter.framework">
+    <NativeReference Include="..\..\..\externals\apple\macOS\AppCenter.framework">
       <Kind>Framework</Kind>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lsqlite3</LinkerFlags>

--- a/SDK/AppCenter/Microsoft.AppCenter.MacOS.Bindings/Microsoft.AppCenter.MacOS.Bindings.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.MacOS.Bindings/Microsoft.AppCenter.MacOS.Bindings.csproj
@@ -31,12 +31,12 @@
       <CustomCommands>
         <Command>
           <type>BeforeBuild</type>
-          <command>sh build.sh -t-external-macos</command>
+          <command>sh build.sh -t-Externals-Apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
         <Command>
           <type>AfterClean</type>
-          <command>rm -rf external/macos</command>
+          <command>rm -rf external/apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
       </CustomCommands>
@@ -53,12 +53,12 @@
       <CustomCommands>
         <Command>
           <type>BeforeBuild</type>
-          <command>sh build.sh -t-external-macos</command>
+          <command>sh build.sh -t-Externals-Apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
         <Command>
           <type>AfterClean</type>
-          <command>rm -rf external/macos</command>
+          <command>rm -rf external/apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
       </CustomCommands>

--- a/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Microsoft.AppCenter.iOS.Bindings.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Microsoft.AppCenter.iOS.Bindings.csproj
@@ -34,7 +34,7 @@
         </Command>
         <Command>
           <type>AfterClean</type>
-          <command>rm -rf externals/ios</command>
+          <command>rm -rf externals/apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
       </CustomCommands>
@@ -57,7 +57,7 @@
         </Command>
         <Command>
           <type>AfterClean</type>
-          <command>rm -rf externals/ios</command>
+          <command>rm -rf externals/apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
       </CustomCommands>

--- a/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Microsoft.AppCenter.iOS.Bindings.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Microsoft.AppCenter.iOS.Bindings.csproj
@@ -29,7 +29,7 @@
       <CustomCommands>
         <Command>
           <type>BeforeBuild</type>
-          <command>sh build.sh -t=externals-ios</command>
+          <command>sh build.sh -t=Externals-Apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
         <Command>
@@ -52,7 +52,7 @@
       <CustomCommands>
         <Command>
           <type>BeforeBuild</type>
-          <command>sh build.sh -t=externals-ios</command>
+          <command>sh build.sh -t=Externals-Apple</command>
           <workingdir>${SolutionDir}</workingdir>
         </Command>
         <Command>

--- a/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Microsoft.AppCenter.iOS.Bindings.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.iOS.Bindings/Microsoft.AppCenter.iOS.Bindings.csproj
@@ -77,7 +77,7 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\ios\AppCenter.a">
+    <NativeReference Include="..\..\..\externals\apple\ios\AppCenter.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lsqlite3</LinkerFlags>

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.MacOS.Bindings/Microsoft.AppCenter.Analytics.MacOS.Bindings.csproj
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.MacOS.Bindings/Microsoft.AppCenter.Analytics.MacOS.Bindings.csproj
@@ -49,7 +49,7 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\macos\AppCenterAnalytics.framework">
+    <NativeReference Include="..\..\..\externals\apple\ios\AppCenterAnalytics.framework">
       <Kind>Framework</Kind>
       <ForceLoad>True</ForceLoad>
     </NativeReference>

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.MacOS.Bindings/Microsoft.AppCenter.Analytics.MacOS.Bindings.csproj
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.MacOS.Bindings/Microsoft.AppCenter.Analytics.MacOS.Bindings.csproj
@@ -49,7 +49,7 @@
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\apple\ios\AppCenterAnalytics.framework">
+    <NativeReference Include="..\..\..\externals\apple\macOS\AppCenterAnalytics.framework">
       <Kind>Framework</Kind>
       <ForceLoad>True</ForceLoad>
     </NativeReference>

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS.Bindings/Microsoft.AppCenter.Analytics.iOS.Bindings.csproj
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.iOS.Bindings/Microsoft.AppCenter.Analytics.iOS.Bindings.csproj
@@ -49,7 +49,7 @@
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\ios\AppCenterAnalytics.a">
+    <NativeReference Include="..\..\..\externals\apple\ios\AppCenterAnalytics.a">
       <Kind>Static</Kind>
       <ForceLoad>True</ForceLoad>
     </NativeReference>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.MacOS.Bindings/Microsoft.AppCenter.Crashes.MacOS.Bindings.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.MacOS.Bindings/Microsoft.AppCenter.Crashes.MacOS.Bindings.csproj
@@ -55,7 +55,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\macos\AppCenterCrashes.framework">
+    <NativeReference Include="..\..\..\externals\apple\macos\AppCenterCrashes.framework">
       <Kind>Framework</Kind>
       <ForceLoad>True</ForceLoad>
       <Frameworks />

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.MacOS.Bindings/Microsoft.AppCenter.Crashes.MacOS.Bindings.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.MacOS.Bindings/Microsoft.AppCenter.Crashes.MacOS.Bindings.csproj
@@ -55,7 +55,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\apple\macos\AppCenterCrashes.framework">
+    <NativeReference Include="..\..\..\externals\apple\macOS\AppCenterCrashes.framework">
       <Kind>Framework</Kind>
       <ForceLoad>True</ForceLoad>
       <Frameworks />

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/Microsoft.AppCenter.Crashes.iOS.Bindings.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.iOS.Bindings/Microsoft.AppCenter.Crashes.iOS.Bindings.csproj
@@ -55,7 +55,7 @@
         </ProjectReference>
     </ItemGroup>
     <ItemGroup>
-        <NativeReference Include="..\..\..\externals\ios\AppCenterCrashes.a">
+        <NativeReference Include="..\..\..\externals\apple\ios\AppCenterCrashes.a">
             <Kind>Static</Kind>
             <ForceLoad>True</ForceLoad>
             <Frameworks>

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/Microsoft.AppCenter.Distribute.iOS.Bindings.csproj
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.iOS.Bindings/Microsoft.AppCenter.Distribute.iOS.Bindings.csproj
@@ -57,7 +57,7 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
-    <NativeReference Include="..\..\..\externals\ios\AppCenterDistribute.a">
+    <NativeReference Include="..\..\..\externals\apple\ios\AppCenterDistribute.a">
       <Kind>Static</Kind>
       <SmartLink>False</SmartLink>
       <ForceLoad>True</ForceLoad>
@@ -65,46 +65,46 @@
     </NativeReference>
   </ItemGroup>
   <ItemGroup>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\Info.plist">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\Info.plist">
       <Link>Resources\AppCenterDistributeResources.bundle\Info.plist</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\cs.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\cs.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\cs.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\de.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\de.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\de.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\en.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\en.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\en.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\es.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\es.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\es.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\fr.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\fr.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\fr.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\it.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\it.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\it.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\ja.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\ja.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\ja.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\ko.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\ko.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\ko.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\pl.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\pl.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\pl.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\ru.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\ru.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\ru.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\tr.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\tr.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\tr.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\zh-Hans.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\zh-Hans.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\zh-Hans.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
-    <BundleResource Include="..\..\..\externals\ios\AppCenterDistributeResources.bundle\zh-Hant.lproj\AppCenterDistribute.strings">
+    <BundleResource Include="..\..\..\externals\apple\ios\AppCenterDistributeResources.bundle\zh-Hant.lproj\AppCenterDistribute.strings">
       <Link>Resources\AppCenterDistributeResources.bundle\zh-Hant.lproj\AppCenterDistribute.strings</Link>
     </BundleResource>
   </ItemGroup>

--- a/build.cake
+++ b/build.cake
@@ -32,8 +32,7 @@ IList<AppCenterModule> AppCenterModules = null;
 
 var ExternalsDirectory = "externals";
 var AndroidExternals = $"{ExternalsDirectory}/android";
-var IosExternals = $"{ExternalsDirectory}/ios";
-var MacosExternals = $"{ExternalsDirectory}/macos";
+var AppleExternals = $"{ExternalsDirectory}/apple";
 
 var SdkStorageUrl = "https://mobilecentersdkdev.blob.core.windows.net/sdk/";
 
@@ -98,60 +97,53 @@ Task("Externals-Android")
 }).OnError(HandleError);
 
 // Downloading iOS binaries.
-Task("Externals-Ios")
+Task("Externals-Apple")
     .Does(() =>
 {
-    CleanDirectory(IosExternals);
-    var zipFile = System.IO.Path.Combine(IosExternals, "ios.zip");
+    // CleanDirectory(AppleExternals);
+    var zipFile = System.IO.Path.Combine(AppleExternals, "apple.zip");
 
     // Download zip file containing AppCenter frameworks
     DownloadFile(AppleUrl, zipFile);
-    Unzip(zipFile, IosExternals);
-    var frameworksLocation = System.IO.Path.Combine(IosExternals, "AppCenter-SDK-Apple/iOS");
+
+    StartProcess("unzip", new ProcessSettings{ Arguments = $"-o {zipFile} -d {AppleExternals}" });
+
+    // Unzip(zipFile, AppleExternals);
+    var iosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/iOS");
+    var macosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/macOS");
+
+    // Move iOS frameworks.
+    var iosExternals = System.IO.Path.Combine(AppleExternals, "ios");
+    CleanDirectory(iosExternals);
 
     // Copy the AppCenter binaries directly from the frameworks and add the ".a" extension
-    var files = GetFiles($"{frameworksLocation}/*.framework/AppCenter*");
+    var files = GetFiles($"{iosFrameworksLocation}/*.framework/AppCenter*");
     foreach (var file in files)
     {
         var filename = file.GetFilename();
-        MoveFile(file, $"{IosExternals}/{filename}.a");
+        MoveFile(file, $"{iosExternals}/{filename}.a");
     }
     
     // Copy Distribute resource bundle and copy it to the externals directory.
     var distributeBundle = "AppCenterDistributeResources.bundle";
-    if(DirectoryExists($"{frameworksLocation}/{distributeBundle}"))
+    if(DirectoryExists($"{iosFrameworksLocation}/{distributeBundle}"))
     {
-        MoveDirectory($"{frameworksLocation}/{distributeBundle}", $"{IosExternals}/{distributeBundle}");
-    }
-}).OnError(HandleError);
-
-// Downloading macOS binaries.
-Task("Externals-MacOS")
-    .Does(() =>
-{
-    CleanDirectory(MacosExternals);
-    CopyDirectory($"{IosExternals}/AppCenter-SDK-Apple", $"{MacosExternals}/AppCenter-SDK-Apple");
-
-    var frameworksLocation = System.IO.Path.Combine(MacosExternals, "AppCenter-SDK-Apple/macOS");
-
-    // Copy the AppCenter binaries directly from the frameworks and add the ".a" extension
-    var files = GetFiles($"{frameworksLocation}/*.framework/Versions/A/AppCenter*");
-    foreach (var file in files)
-    {
-        var filename = file.GetFilename();
-        CopyFile(file, $"{MacosExternals}/{filename}.a");
+        MoveDirectory($"{iosFrameworksLocation}/{distributeBundle}", $"{iosExternals}/{distributeBundle}");
     }
 
-    //generate correct .framework directories
-    CopyDirectory($"{frameworksLocation}/AppCenter.framework/Versions/A", $"{MacosExternals}/AppCenter.framework");
-    CopyDirectory($"{frameworksLocation}/AppCenterAnalytics.framework/Versions/A", $"{MacosExternals}/AppCenterAnalytics.framework");
-    CopyDirectory($"{frameworksLocation}/AppCenterCrashes.framework/Versions/A", $"{MacosExternals}/AppCenterCrashes.framework");
+    // Move macOS frameworks.
+    var macosExternals = System.IO.Path.Combine(AppleExternals, "macos");
+    CleanDirectory(macosExternals);
+    var frameworks = GetDirectories($"{macosFrameworksLocation}/*.framework");
+    foreach (var frameworkDir in frameworks)
+    {
+        var dirName = frameworkDir.GetDirectoryName();
+        MoveDirectory(frameworkDir, $"{macosExternals}/{dirName}");
+    }
 }).OnError(HandleError);
-
-
 
 // Create a common externals task depending on platform specific ones
-Task("Externals").IsDependentOn("Externals-Ios").IsDependentOn("Externals-MacOS").IsDependentOn("Externals-Android");
+Task("Externals").IsDependentOn("Externals-Apple").IsDependentOn("Externals-Android");
 
 // Main Task.
 Task("Default").IsDependentOn("NuGet").IsDependentOn("RemoveTemporaries");

--- a/build.cake
+++ b/build.cake
@@ -108,7 +108,19 @@ Task("Externals-Apple")
     DownloadFile(AppleUrl, zipFile);
 
     // Unzip.
-    StartProcess("unzip", new ProcessSettings{ Arguments = $"{zipFile} -d {AppleExternals}" });
+    // StartProcess("unzipr", new ProcessSettings{ Arguments = $"{zipFile} -d {AppleExternals}" });
+    using(var process = StartAndReturnProcess("unzip",
+        new ProcessSettings { Arguments =new ProcessArgumentBuilder()
+            .Append(zipFile)
+            .Append("-d")
+            .Append(AppleExternals)
+        }))
+    {
+        process.WaitForExit();
+        // This should output 0 as valid arguments supplied
+        Information($"Exit code: {process.GetExitCode()}");
+        Information($"error: {process.GetStandardError()}, output: {process.GetStandardError()}");
+    }
 
     var iosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/iOS");
     var macosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/macOS");

--- a/build.cake
+++ b/build.cake
@@ -98,6 +98,7 @@ Task("Externals-Android")
 
 // Downloading iOS binaries.
 Task("Externals-Apple")
+    .WithCriteria(() => IsRunningOnUnix())
     .Does(() =>
 {
     CleanDirectory(AppleExternals);

--- a/build.cake
+++ b/build.cake
@@ -100,15 +100,15 @@ Task("Externals-Android")
 Task("Externals-Apple")
     .Does(() =>
 {
-    // CleanDirectory(AppleExternals);
+    CleanDirectory(AppleExternals);
     var zipFile = System.IO.Path.Combine(AppleExternals, "apple.zip");
 
-    // Download zip file containing AppCenter frameworks
+    // Download zip file containing AppCenter frameworks.
     DownloadFile(AppleUrl, zipFile);
 
+    // Unzip.
     StartProcess("unzip", new ProcessSettings{ Arguments = $"-o {zipFile} -d {AppleExternals}" });
 
-    // Unzip(zipFile, AppleExternals);
     var iosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/iOS");
     var macosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/macOS");
 
@@ -116,7 +116,7 @@ Task("Externals-Apple")
     var iosExternals = System.IO.Path.Combine(AppleExternals, "ios");
     CleanDirectory(iosExternals);
 
-    // Copy the AppCenter binaries directly from the frameworks and add the ".a" extension
+    // Copy the AppCenter binaries directly from the frameworks and add the ".a" extension.s
     var files = GetFiles($"{iosFrameworksLocation}/*.framework/AppCenter*");
     foreach (var file in files)
     {

--- a/build.cake
+++ b/build.cake
@@ -108,7 +108,7 @@ Task("Externals-Apple")
     DownloadFile(AppleUrl, zipFile);
 
     // Unzip.
-    StartProcess("unzip", new ProcessSettings{ Arguments = $"-o {zipFile} -d {AppleExternals}" });
+    StartProcess("unzip", new ProcessSettings{ Arguments = $"{zipFile} -d {AppleExternals}" });
 
     var iosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/iOS");
     var macosFrameworksLocation = System.IO.Path.Combine(AppleExternals, "AppCenter-SDK-Apple/macOS");


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
* ~[ ] Are tests passing locally?~
* ~[ ] Did you add unit tests if this modifies the Windows code?~

## Description

This PR fixes App Store Connect validation errors for a Mac application:
```
ITMS-90291: Malformed Framework - The framework bundle AppCenter (MyApp.app/Contents/Frameworks/AppCenter.framework) must contain a symbolic link 'AppCenter' -> 'Versions/Current/AppCenter'. Refer to the Anatomy of Framework Bundles for more information. 
ITMS-90291: Malformed Framework - The framework bundle AppCenter (MyApp.app/Contents/Frameworks/AppCenter.framework) must contain a symbolic link 'Resources' -> 'Versions/Current/Resources'. Refer to the Anatomy of Framework Bundles for more information. 
ITMS-90292: Malformed Framework - The framework bundle AppCenter (MyApp.app/Contents/Frameworks/AppCenter.framework) 'Versions' directory must contain a symbolic link 'Current' resolving to a specific version directory. Resolved link target: '${linkTarget}'. Refer to the Anatomy of Framework Bundles for more information. 
```

This was due to the wrong structure in App Center mac frameworks. Fixed by modifying the process of integrating the native frameworks.

## Related PRs or issues

[AB#90090](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/90090)