### PR TITLE
Improve/fix CreateModelExceptionAndBinaries

### DIFF
--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.WindowsDesktop/Utils/ErrorLogHelperPart.cs
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.WindowsDesktop/Utils/ErrorLogHelperPart.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AppCenter.Crashes.Utils
                     }
                 }
             }
-            if (exception.InnerException != null)
+            else if (exception.InnerException != null)
             {
                 modelException.InnerExceptions = modelException.InnerExceptions ?? new List<ModelException>();
                 modelException.InnerExceptions.Add(CreateModelExceptionAndBinaries(exception.InnerException).Exception);


### PR DESCRIPTION
There appears to be a small bug in the `CreateModelExceptionAndBinaries` method. If it processes an `AggregateException`, it will actually add the inner exception twice because of the second if block. I confirmed it by debugging - at the end, `modelException.InnerExceptions` has 2 list items that are the same. Since the first if block processes the inner exceptions of the `AggregateException`, it's not necessary to execute the second if block unless the exception is **not** an `AggregateException`.

If this was by design for some reason, let me know. Seems like a bug, though. I don't see why you would want to duplicate the same inner exception.