### PR TITLE
Fix appVersion fallback when targeting WPF app to net6.0-windows10.0.18362.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * **[Fix]** Fix crash when retrieving device info on early Windows versions.
 
+#### WPF
+
+* **[Fix]** Fix version reporting for non-WinUI applications when target framework is `net5.0-windows10.0.17763.0` or higher..
+
 ___
 
 ## Version 4.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 #### WPF
 
-* **[Fix]** Fix version reporting for non-WinUI applications when target framework is `net5.0-windows10.0.17763.0` or higher..
+* **[Fix]** Fix version reporting for non-WinUI applications when target framework is `net5.0-windows10.0.17763.0` or higher.
 
 ___
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -190,19 +190,10 @@ namespace Microsoft.AppCenter.Utils
 
         protected override string GetAppVersion()
         {
-            string productVersion = null;
-            try
-            {
-                productVersion = GetWinFormsAppVersion();
-            }
-            catch(Exception exception)
-            {
-                AppCenterLog.Warn(AppCenterLog.LogTag, "Failed to get product version with error: ", exception);
-            }
-            return DeploymentVersion ?? PackageVersion ?? productVersion ?? _defaultVersion;
+            return DeploymentVersion ?? PackageVersion ?? TryToGetWinFormsAppVersion() ?? _defaultVersion;
         }
 
-        private string GetWinFormsAppVersion()
+        private static string GetWinFormsAppVersion()
         {
             /*
              * Application.ProductVersion returns the value from AssemblyInformationalVersion.
@@ -210,6 +201,19 @@ namespace Microsoft.AppCenter.Utils
              * the version number specified by the AssemblyFileVersion attribute is used instead.
              */
             return System.Windows.Forms.Application.ProductVersion;
+        }
+
+        private static string TryToGetWinFormsAppVersion()
+        {
+            try
+            {
+                return GetWinFormsAppVersion();
+            }
+            catch (Exception exception)
+            {
+                AppCenterLog.Warn(AppCenterLog.LogTag, "Failed to get product version with error: ", exception);
+                return null;
+            }
         }
 
         protected override string GetAppBuild()
@@ -289,9 +293,10 @@ namespace Microsoft.AppCenter.Utils
                 }
 
                 // Fallback if entry assembly is not found (in unit tests for example).
-                return Application.ProductVersion;
-#endif
+                return TryToGetWinFormsAppVersion();
+#else
                 return null;
+#endif
             }
         }
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -7,7 +7,6 @@ using System.Drawing;
 using System.Management;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Windows.Forms;
 #if WINDOWS10_0_17763_0
 using Windows.ApplicationModel;
 #endif
@@ -191,21 +190,26 @@ namespace Microsoft.AppCenter.Utils
 
         protected override string GetAppVersion()
         {
-            /*
-             * Application.ProductVersion returns the value from AssemblyInformationalVersion.
-             * If the AssemblyInformationalVersion is not applied to an assembly,
-             * the version number specified by the AssemblyFileVersion attribute is used instead.
-             */
             string productVersion = null;
             try
             {
-                productVersion = Application.ProductVersion;
+                productVersion = GetWinFormsAppVersion();
             }
             catch(Exception exception)
             {
                 AppCenterLog.Warn(AppCenterLog.LogTag, "Failed to get product version with error: ", exception);
             }
             return DeploymentVersion ?? PackageVersion ?? productVersion ?? _defaultVersion;
+        }
+
+        private string GetWinFormsAppVersion()
+        {
+            /*
+             * Application.ProductVersion returns the value from AssemblyInformationalVersion.
+             * If the AssemblyInformationalVersion is not applied to an assembly,
+             * the version number specified by the AssemblyFileVersion attribute is used instead.
+             */
+            return System.Windows.Forms.Application.ProductVersion;
         }
 
         protected override string GetAppBuild()

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -196,7 +196,16 @@ namespace Microsoft.AppCenter.Utils
              * If the AssemblyInformationalVersion is not applied to an assembly,
              * the version number specified by the AssemblyFileVersion attribute is used instead.
              */
-            return DeploymentVersion ?? PackageVersion ?? Application.ProductVersion ?? _defaultVersion;
+            string productVersion = null;
+            try
+            {
+                productVersion = Application.ProductVersion;
+            }
+            catch(Exception exception)
+            {
+                AppCenterLog.Warn(AppCenterLog.LogTag, "Failed to get product version with error: ", exception);
+            }
+            return DeploymentVersion ?? PackageVersion ?? productVersion ?? _defaultVersion;
         }
 
         protected override string GetAppBuild()

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -4,15 +4,12 @@
 using System;
 using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using System.Management;
 using System.Reflection;
 using System.Runtime.InteropServices;
-
+using System.Windows.Forms;
 #if WINDOWS10_0_17763_0
 using Windows.ApplicationModel;
-#else
-using System.Windows.Forms;
 #endif
 
 #if NET461 || NET472
@@ -199,11 +196,7 @@ namespace Microsoft.AppCenter.Utils
              * If the AssemblyInformationalVersion is not applied to an assembly,
              * the version number specified by the AssemblyFileVersion attribute is used instead.
              */
-            string productVersion = null;
-#if !WINDOWS10_0_17763_0
-            productVersion = Application.ProductVersion;
-#endif
-            return DeploymentVersion ?? productVersion ?? PackageVersion ?? _defaultVersion;
+            return DeploymentVersion ?? PackageVersion ?? Application.ProductVersion ?? _defaultVersion;
         }
 
         protected override string GetAppBuild()


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

An incorrect condition was used to set the version.

## Related PRs or issues

[AB#92533](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/92533)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1644/