### PR TITLE
Fix MAUI unpackaged windows app crash on AppCenter.Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * **[Fix]** Fix crash on net6.0-macos application because of an incorrect native binary linking.
 
+#### Windows
+
+* **[Fix]** Fix crash on MAUI windows unpackaged application due to picking a wrong lifecycle helper.
+
 ___
 
 ## Version 5.0.0-preview.1

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelper.cs
@@ -32,16 +32,16 @@ namespace Microsoft.AppCenter
                 if (_instance == null)
                 {
 #if WINDOWS10_0_17763_0_OR_GREATER
-                    if (WindowsHelper.IsRunningAsUwp)
+                    if (WindowsHelper.IsRunningAsWinUI)
                     {
-                        _instance = new ApplicationLifecycleHelperWinUI();
                         AppCenterLog.Debug(AppCenterLog.LogTag, "Use lifecycle for WinUI applications.");
+                        _instance = new ApplicationLifecycleHelperWinUI();
                     }
                     else
 #endif
                     {
-                        _instance = new ApplicationLifecycleHelperDesktop();
                         AppCenterLog.Debug(AppCenterLog.LogTag, "Use lifecycle for desktop applications.");
+                        _instance = new ApplicationLifecycleHelperDesktop();
                     }
                 }
                 return _instance;

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/DeviceInformationHelper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AppCenter.Utils
         {
             var sdkName = WindowsHelper.IsRunningAsWpf ? "appcenter.wpf" : "appcenter.winforms";
 #if WINDOWS
-            sdkName = WindowsHelper.IsRunningAsUwp ? "appcenter.winui" : $"{sdkName}.net";
+            sdkName = WindowsHelper.IsRunningAsWinUI ? "appcenter.winui" : $"{sdkName}.net";
 #elif NETCOREAPP
             sdkName = $"{sdkName}.netcore";
 #endif

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
@@ -21,6 +21,8 @@ namespace Microsoft.AppCenter.Utils
 
         public static bool IsRunningAsUwp { get; }
 
+        public static bool IsRunningAsWinUI { get; }
+
         #region IsRunningAsUwp
 
         const long APPMODEL_ERROR_NO_PACKAGE = 15700L;
@@ -107,7 +109,6 @@ namespace Microsoft.AppCenter.Utils
             try
             {
                 var presentationFramework = GetAssembly("PresentationFramework");
-
                 IsRunningAsWpf = presentationFramework != null;
                 if (IsRunningAsWpf)
                 {
@@ -123,6 +124,7 @@ namespace Microsoft.AppCenter.Utils
                 AppCenterLog.Warn(AppCenterLog.LogTag, "Unabled to determine whether this application is WPF or Windows Forms; proceeding as though it is Windows Forms.");
             }
             IsRunningAsUwp = _IsRunningAsUwp();
+            IsRunningAsWinUI = IsRunningAsUwp || GetAssembly("System.Windows.Forms") == null;
         }
 
         private static dynamic WpfApplication { get; }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests if this modifies the Windows code?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes crash on AppCenter.Start for an unpackaged windows MAUI application.

## Related PRs or issues

[AB#95592](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/95592)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1693
