### PR TITLE
Start release 5.0.0

### DIFF
--- a/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Android.Puppet/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.puppet" android:versionCode="109" android:versionName="5.0.0-SNAPSHOT" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.puppet" android:versionCode="110" android:versionName="5.0.0-SNAPSHOT" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<application android:label="SXPuppet" android:icon="@drawable/Icon" android:theme="@style/PuppetTheme"></application>
 </manifest>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Contoso.Forms.Demo.Droid.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Contoso.Forms.Demo.Droid.csproj
@@ -73,14 +73,14 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)'=='GooglePlay' ">
-    <PackageReference Include="Microsoft.AppCenter.DistributePlay" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.DistributePlay" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)'!='GooglePlay' ">
-    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.forms.demo" android:versionName="4.5.3" android:versionCode="95">
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.microsoft.appcenter.xamarin.forms.demo" android:versionName="5.0.0" android:versionCode="96">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<application android:label="ACFDemo"></application>
 </manifest>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.Droid/Properties/AssemblyInfo.cs
@@ -22,8 +22,8 @@ using Android.App;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("4.5.3.0")]
-[assembly: AssemblyInformationalVersion("4.5.3")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.MacOS/Contoso.Forms.Demo.MacOS.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.MacOS/Contoso.Forms.Demo.MacOS.csproj
@@ -58,9 +58,9 @@
     <Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.MacOS/Info.plist
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.MacOS/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.microsoft.appcenter.Contoso-Forms-Demo-MacOS</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.5.3</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>4.5.3</string>
+	<string>5.0.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Contoso.Forms.Demo.UWP.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Contoso.Forms.Demo.UWP.csproj
@@ -136,9 +136,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1821" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
   </ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Package.appxmanifest
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="10805zumoTestUser.AppCenter-Contoso.Forms.Demo.UWP" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="4.5.3.0" />
+  <Identity Name="10805zumoTestUser.AppCenter-Contoso.Forms.Demo.UWP" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="5.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="fbe02dcf-2c7d-4740-9c2b-0df5e15916e5" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>AppCenter-Contoso.Forms.Demo.UWP</DisplayName>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.UWP/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("4.5.3.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
 [assembly: ComVisible(false)]

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Contoso.Forms.Demo.iOS.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Contoso.Forms.Demo.iOS.csproj
@@ -93,9 +93,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Info.plist
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.microsoft.appcenter.xamarin.forms.ios.demo</string>
 	<key>CFBundleVersion</key>
-	<string>4.5.3</string>
+	<string>5.0.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
@@ -39,7 +39,7 @@
 	<key>CFBundleName</key>
 	<string>ACFDemo</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.5.3</string>
+	<string>5.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Contoso.Forms.Demo.csproj
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo/Contoso.Forms.Demo.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>Microsoft Corp. All rights reserved.</Copyright>
     <Company>Microsoft Corporation</Company>
-    <Version>4.5.3</Version>
+    <Version>5.0.0</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>4.5.3.0</FileVersion>
+    <FileVersion>5.0.0.0</FileVersion>
     <Configurations>Debug;Release;GooglePlay</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'GooglePlay|AnyCPU' ">
@@ -20,14 +20,14 @@
     <NoStdLib>false</NoStdLib>
   </PropertyGroup>
   <ItemGroup Condition=" '$(Configuration)'!='GooglePlay' ">
-    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)'=='GooglePlay' ">
-    <PackageReference Include="Microsoft.AppCenter.DistributePlay" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.DistributePlay" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2401" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
+++ b/Apps/Contoso.Forms.Puppet/Contoso.Forms.Puppet.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="110" android:versionName="5.0.0-SNAPSHOT" package="com.microsoft.appcenter.xamarin.forms.puppet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="111" android:versionName="5.0.0-SNAPSHOT" package="com.microsoft.appcenter.xamarin.forms.puppet">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<application android:label="ACFPuppet"></application>
 </manifest>

--- a/Apps/Contoso.MAUI.Demo/Contoso.MAUI.Demo.csproj
+++ b/Apps/Contoso.MAUI.Demo/Contoso.MAUI.Demo.csproj
@@ -8,15 +8,12 @@
     <UsingMauiEssentials>true</UsingMauiEssentials>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>5.0.0-SNAPSHOT</Version>
-
+    <Version>5.0.0</Version>
     <!-- Display name -->
     <ApplicationTitle>Contoso.MAUI.Demo</ApplicationTitle>
-
     <!-- App Identifier -->
     <ApplicationId>com.microsoft.appcenter.Contoso.MAUI.Demo</ApplicationId>
     <ApplicationIdGuid>d7a06185-3470-4ae9-8a6f-27a861f146b2</ApplicationIdGuid>
-
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
@@ -25,7 +22,6 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <Configurations>Debug;Release;GooglePlay</Configurations>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'GooglePlay|AnyCPU' ">
     <IntermediateOutputPath>obj\GooglePlay</IntermediateOutputPath>
     <DebugType></DebugType>
@@ -40,18 +36,14 @@
   <ItemGroup>
     <!-- App Icon -->
     <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
-
     <!-- Splash Screen -->
     <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
-
     <!-- Images -->
     <MauiImage Include="Resources\Images\*" />
     <MauiFont Include="Resources\Fonts\*" />
-
     <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="Microsoft.AppCenter.Analytics" />
     <None Remove="Microsoft.AppCenter.Crashes" />
@@ -63,13 +55,13 @@
     <None Remove="Platforms\iOS\Resources\Images\socket.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0007-5d0e348" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0007-5d0e348" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)'!='GooglePlay' ">
-    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Distribute" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)'=='GooglePlay' ">
-    <PackageReference Include="Microsoft.AppCenter.DistributePlay" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.DistributePlay" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/Apps/Contoso.MAUI.Demo/Platforms/Windows/Package.appxmanifest
+++ b/Apps/Contoso.MAUI.Demo/Platforms/Windows/Package.appxmanifest
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=Microsoft" Version="0.0.0.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=Microsoft" Version="5.0.0.0" />
 
   <Properties>
     <DisplayName>$placeholder$</DisplayName>

--- a/Apps/Contoso.UWP.Demo/Contoso.UWP.Demo.csproj
+++ b/Apps/Contoso.UWP.Demo/Contoso.UWP.Demo.csproj
@@ -149,8 +149,8 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.UWP.Demo/Package.appxmanifest
+++ b/Apps/Contoso.UWP.Demo/Package.appxmanifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="10805zumoTestUser.AppCenter-Contoso.UWP.Demo" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="4.5.3.0" />
+  <Identity Name="10805zumoTestUser.AppCenter-Contoso.UWP.Demo" Publisher="CN=B2D1C358-6AF8-4416-BF73-129CC1F3C152" Version="5.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="3bda7e44-ab20-4885-b6a0-121b9f9e33d7" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>AppCenter-Contoso.UWP.Demo</DisplayName>

--- a/Apps/Contoso.UWP.Demo/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.UWP.Demo/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("4.5.3.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
 [assembly: ComVisible(false)]

--- a/Apps/Contoso.WPF.Demo.DotNetCore/Contoso.WPF.Demo.DotNetCore.csproj
+++ b/Apps/Contoso.WPF.Demo.DotNetCore/Contoso.WPF.Demo.DotNetCore.csproj
@@ -4,13 +4,13 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
-    <Version>4.5.3</Version>
+    <Version>5.0.0</Version>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <FileVersion>4.5.3.0</FileVersion>
+    <FileVersion>5.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.WPF.Demo/Contoso.WPF.Demo.csproj
+++ b/Apps/Contoso.WPF.Demo/Contoso.WPF.Demo.csproj
@@ -115,8 +115,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Apps/Contoso.WPF.Demo/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.WPF.Demo/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("4.5.3.0")]
-[assembly: AssemblyInformationalVersion("4.5.3")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]

--- a/Apps/Contoso.WinForms.Demo.DotNetCore/Contoso.WinForms.Demo.DotNetCore.csproj
+++ b/Apps/Contoso.WinForms.Demo.DotNetCore/Contoso.WinForms.Demo.DotNetCore.csproj
@@ -4,11 +4,11 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <Version>4.5.3</Version>
+    <Version>5.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Contoso.WinForms.Demo/Contoso.WinForms.Demo.csproj
+++ b/Apps/Contoso.WinForms.Demo/Contoso.WinForms.Demo.csproj
@@ -81,8 +81,8 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Apps/Contoso.WinForms.Demo/Properties/AssemblyInfo.cs
+++ b/Apps/Contoso.WinForms.Demo/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("4.5.3.0")]
-[assembly: AssemblyInformationalVersion("4.5.3")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]

--- a/Apps/Contoso.WinUI.Desktop.Demo/Contoso.WinUI.Desktop.Demo (Package)/Package.appxmanifest
+++ b/Apps/Contoso.WinUI.Desktop.Demo/Contoso.WinUI.Desktop.Demo (Package)/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="1351d609-eaaa-44b8-8752-b6bab406bb98"
     Publisher="CN=Microsoft.AppCenter"
-    Version="4.5.3.0" />
+    Version="5.0.0.0" />
 
   <Properties>
     <DisplayName>Contoso.WinUI.Desktop.Demo (Package)</DisplayName>

--- a/Apps/Contoso.WinUI.Desktop.Demo/Contoso.WinUI.Desktop.Demo/Contoso.WinUI.Desktop.Demo.csproj
+++ b/Apps/Contoso.WinUI.Desktop.Demo/Contoso.WinUI.Desktop.Demo/Contoso.WinUI.Desktop.Demo.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.6.0-r0006-5d28fad" />
-    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.6.0-r0006-5d28fad" />
+    <PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.ProjectReunion" Version="0.8.1" />
     <PackageReference Include="Microsoft.ProjectReunion.Foundation" Version="0.8.1" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,27 @@
 #### Apple
 
 * **[Fix]** Fix crash on net6.0-macos application because of an incorrect native binary linking.
+* **[Feature]** Add Xcode 14 support. Xcode 11 and Xcode 12 are out of support now. Bump minumum supported iOS version to iOS 11.
+
+#### Android
+
+* **[Fix]** Fix ignoring maximum storage size limit in case logs contain large payloads.
 
 #### Windows
 
 * **[Fix]** Fix crash on MAUI windows unpackaged application due to picking a wrong lifecycle helper.
+
+### App Center Crashes
+
+#### Apple
+
+* **[Improvement]** Update PLCrashReporter to 1.11.0.
+
+### App Center Distribute
+
+#### Android
+
+* **[Feature]** Add requesting notifications permission for Android 13 (notifications are used to inform about downloading/installing status if an application is in background)
 
 ___
 

--- a/Tests/Contoso.Test.Functional.Droid/Properties/AndroidManifest.xml
+++ b/Tests/Contoso.Test.Functional.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="41" android:versionName="5.0.0-SNAPSHOT" package="com.contoso.test.functional">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="42" android:versionName="5.0.0-SNAPSHOT" package="com.contoso.test.functional">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<application android:label="Contoso.Test.Functional.Droid">

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -6,7 +6,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/appcenter-sdk-android.git",
-          "commitHash": "39fd75a22285ba8d9d3146bff6f6946007f78533"
+          "commitHash": "c53920a71178100ad6658ff3f23528ee4c501462"
         }
       }
     },
@@ -15,7 +15,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/appcenter-sdk-apple.git",
-          "commitHash": "b2dc99cfedead0bad4e6573d86c5228c89cff332"
+          "commitHash": "88e65475ffd3a7cf2bbde07df9e62159a1fd60a8"
         }
       }
     }

--- a/scripts/configuration/ac-build-config.xml
+++ b/scripts/configuration/ac-build-config.xml
@@ -2,8 +2,8 @@
 <config>
     <sdkInfo>
         <sdkVersion>5.0.0-SNAPSHOT</sdkVersion>
-        <appleVersion>4.4.3</appleVersion>
-        <androidVersion>4.4.5</androidVersion>
+        <appleVersion>5.0.0</appleVersion>
+        <androidVersion>5.0.0</androidVersion>
     </sdkInfo>
     <group id="ios" buildGroup="mac">
         <assembly path="SDK/AppCenter/Microsoft.AppCenter.Apple/bin/Release/xamarin.ios/Microsoft.AppCenter.dll"/>

--- a/version.cake
+++ b/version.cake
@@ -294,6 +294,10 @@ void IncrementManifestVersionCode(FilePath manifest)
 {
     var versionCodePattern = "android:versionCode=\"[^\"]+\"";
     var versionCodeText = FindRegexMatchInFile(manifest, versionCodePattern, RegexOptions.None);
+    if (string.IsNullOrEmpty(versionCodeText))
+    {
+        return;
+    }
     var firstPart = "android:versionCode=\"";
     var length = versionCodeText.Length - 1 - firstPart.Length;
     var versionCode = int.Parse(versionCodeText.Substring(firstPart.Length, length));


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?

## Description

### Version 5.0.0

* **[Fix]** Fix crash on net6.0-macos application because of an incorrect native binary linking.
* **[Feature]** Add Xcode 14 support. Xcode 11 and Xcode 12 are out of support now. Bump minumum supported iOS version to iOS 11.
* **[Fix]** Fix ignoring maximum storage size limit in case logs contain large payloads.
* **[Fix]** Fix crash on MAUI windows unpackaged application due to picking a wrong lifecycle helper.
* **[Improvement]** Update PLCrashReporter to 1.11.0.
* **[Feature]** Add requesting notifications permission for Android 13 (notifications are used to inform about downloading/installing status if an application is in background)

## Related PRs or issues

[AB#95811](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/95811)
