### PR TITLE
Register AppDelegate dependency.

### DIFF
--- a/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.MacOS/AppDelegate.cs
+++ b/Apps/Contoso.Forms.Demo/Contoso.Forms.Demo.MacOS/AppDelegate.cs
@@ -4,7 +4,10 @@
 using AppKit;
 using Foundation;
 using Xamarin.Forms.Platform.MacOS;
+using Xamarin.Forms;
+using Contoso.Forms.Demo.MacOS;
 
+[assembly: Dependency(typeof(AppDelegate))]
 namespace Contoso.Forms.Demo.MacOS
 {
     [Register("AppDelegate")]


### PR DESCRIPTION
## Description
IClearCrashClick was not registered in DependencyService causing NRE when trying to call 'ClearCrashButton'
