### PR TITLE
#1709 Fixing the OSVersion check to work on Windows 7 SP1 (6.1.7601.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # App Center SDK for .NET Change Log
-## Version 5.0.1
+## Version 5.0.2
 
 #### Windows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # App Center SDK for .NET Change Log
+## Version 5.0.1
+
+#### Windows
+
+* **[Fix]** Fix crash on Windows 7 during intialization for Microsoft.AppCenter.Utils. WindowsHelper. _IsRunningAsUwp() because of an incorrect OSVersion check.
 
 ## Version 5.0.0
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AppCenter.Utils
 
         private static bool _IsRunningAsUwp()
         {
-            if (Environment.OSVersion.Version <= new Version(6, 1))
+            if (Environment.OSVersion.Version < new Version(6, 2))
             {
                 return false;
             }


### PR DESCRIPTION
#1709 Fixing the OSVersion check to work on Windows 7 SP1 (6.1.7601.0), AppCenter was crashing on initialization for Windows 7.

## Description
I found a bug preventing me from using the latest AppCenter in our software on Windows 7 and I'm trying to help fix it.
