### PR TITLE
#1709 Fixing WindowsHelper _IsRunningAsUwp OSVersion check to account for Windows 7 sp1 (6.1.7601.0)

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AppCenter.Utils
 
         private static bool _IsRunningAsUwp()
         {
-            if (Environment.OSVersion.Version <= new Version(6, 1))
+            if (Environment.OSVersion.Version < new Version(6, 2))
             {
                 return false;
             }


### PR DESCRIPTION
#1709 Updating WindowsHelper _IsRunningAsUwp OSVersion check to account for Windows 7 sp1 (6.1.7601.0).

On Windows 7 when the property _IsRunningAsUwp  was called the function GetCurrentPackageFullName was throwing an exception instead of returning false.

System.EntryPointNotFoundException: Unable to find an entry point named
'GetCurrentPackageFullName' in DLL 'kernel32.dll.
at Microsoft.AppCenter.Utils.WindowsHelper.GetCurrentPackageFulIName(Int32& packageFullNameLength, StringBuilder packageFullName) at Microsoft.AppCenter.Utils. WindowsHelper. _IsRunningAsUwp() Microsoft.AppCenter.Utils.WindowsHelper.cctor0