### PR TITLE
Fixing WindowsHelper OSVersion for Windows 7 sp1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # App Center SDK for .NET Change Log
 
+## Version 5.0.1
+
+### App Center
+
+#### Windows
+
+* **[Fix]** Fixing WindowsHelper OSVersion for Windows 7 sp1
+
+___
+
+
 ## Version 5.0.0
 
 ### App Center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Windows
 
-* **[Fix]** Fixing WindowsHelper OSVersion for Windows 7 sp1
+* **[Fix]** Fix WindowsHelper's OSVersion check for Windows 7 sp1
 
 ___
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AppCenter.Utils
 
         private static bool _IsRunningAsUwp()
         {
-           if (Environment.OSVersion.Version < new Version(6, 2))
+            if (Environment.OSVersion.Version < new Version(6, 2))
             {
                 return false;
             }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AppCenter.Utils
 
         private static bool _IsRunningAsUwp()
         {
-            if (Environment.OSVersion.Version <= new Version(6, 1))
+           if (Environment.OSVersion.Version < new Version(6, 2))
             {
                 return false;
             }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~~[ ] Did you add unit tests if this modifies the Windows code?~~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This was a contribution created in a fork, and I just created a branch and a new PR for it:

 Updating WindowsHelper _IsRunningAsUwp OSVersion check to account for Windows 7 sp1 (6.1.7601.0).

On Windows 7 when the property _IsRunningAsUwp was called the function GetCurrentPackageFullName was throwing an exception instead of returning false.

System.EntryPointNotFoundException: Unable to find an entry point named
'GetCurrentPackageFullName' in DLL 'kernel32.dll.
at Microsoft.AppCenter.Utils.WindowsHelper.GetCurrentPackageFulIName(Int32& packageFullNameLength, StringBuilder packageFullName) at Microsoft.AppCenter.Utils. WindowsHelper. _IsRunningAsUwp() Microsoft.AppCenter.Utils.WindowsHelper.cctor0

## Related PRs or issues

[AB#96577](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/96577)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
