### PR TITLE
Don't use RegexOptions.Compiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **[Fix]** Update `Newtonsoft.Json` dependency to version `13.0.2`. The update fixes [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
 * **[Improvement]** Remove SmartLink=false, as it may break the SDK integration in some cases.
+* **[Improvement]** Remove flag RegexOptions.Compiled, as it is proved to be slow on net6 and above.
 
 #### Windows
 

--- a/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.Shared.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.Shared.cs
@@ -20,11 +20,7 @@ namespace Microsoft.AppCenter
         const string AppSecretKeyName = "appsecret";
         const string SecretsPattern = @"([^;=]+)=([^;]+)(?:;\s*)?";
 
-#if (NETSTANDARD || IOS || ANDROID)
         static readonly Regex _secretsRegex = new Regex(SecretsPattern);
-#else
-        static readonly Regex _secretsRegex = new Regex(SecretsPattern, RegexOptions.Compiled);
-#endif
 
         // Gets the first instance of an app sceret and/or target token corresponding to the given platform name, or returns the string 
         // as-is if no identifier can be found. Logs a message if no identifiers can be found.

--- a/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.Shared.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.Shared/AppCenter.Shared.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AppCenter
         const string AppSecretKeyName = "appsecret";
         const string SecretsPattern = @"([^;=]+)=([^;]+)(?:;\s*)?";
 
-#if NETSTANDARD
+#if (NETSTANDARD || IOS || ANDROID)
         static readonly Regex _secretsRegex = new Regex(SecretsPattern);
 #else
         static readonly Regex _secretsRegex = new Regex(SecretsPattern, RegexOptions.Compiled);


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests if this modifies the Windows code?~
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Using RegexOptions.Compiled on mobile platforms is slowing down the performance since NET6.
The issue was discussed here: https://github.com/dotnet/runtime/issues/71007.

Normally AppCenter.Start should be called once.
In case the AppCenter.Start is called multiple times,
it won't improve the performance significantly. Moreover,
it is ignored on Xamarin.Android and mono, and gets much longer
to execute on net6+ for Android. See benchmark results here:
https://github.com/jonathanpeppers/BenchmarkDotNet-Android

There was a discussion on whether this flag should be set here:
https://github.com/microsoft/appcenter-sdk-dotnet/pull/1253#pullrequestreview-330047060

Based on the discussion, the final point was that Xamarin Forms may
call onStart multiple times. The documentation says:

> On Android, the OnStart method will be called on rotation as well as when the application first starts, if the main activity lacks ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation in the [Activity()] attribute.

However, since the flag is ignored on Xamarin.Android, it doesn't help us with this scenario anyway.

## Related PRs or issues

#1730
[AB#98868](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/98868)
