### PR TITLE
Fix sending crashes fot WPF apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### App Center
 
 * **[Fix]** Update `Newtonsoft.Json` dependency to version `13.0.2`. The update fixes [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
-* **[Fix]** Use `DispatcherUnhandledException` instead of `AppDomain.CurrentDomain.UnhandledException` for WPF applications for postcrash processing. It`s fix [#1727](https://github.com/microsoft/appcenter-sdk-dotnet/issues/1727).
+* **[Fix]** Use `DispatcherUnhandledException` instead of `AppDomain.CurrentDomain.UnhandledException` for WPF applications for postcrash processing. It fixes #1727.
 * **[Improvement]** Remove SmartLink=false, as it may break the SDK integration in some cases.
 * **[Improvement]** Remove flag RegexOptions.Compiled, as it is proved to be slow on net6 and above.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center
 
 * **[Fix]** Update `Newtonsoft.Json` dependency to version `13.0.2`. The update fixes [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr).
+* **[Fix]** Use `DispatcherUnhandledException` instead of `AppDomain.CurrentDomain.UnhandledException` for WPF applications for postcrash processing. It`s fix [#1727](https://github.com/microsoft/appcenter-sdk-dotnet/issues/1727).
 * **[Improvement]** Remove SmartLink=false, as it may break the SDK integration in some cases.
 * **[Improvement]** Remove flag RegexOptions.Compiled, as it is proved to be slow on net6 and above.
 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelperDesktop.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelperDesktop.cs
@@ -42,19 +42,29 @@ namespace Microsoft.AppCenter.Utils
 
         public ApplicationLifecycleHelperDesktop()
         {
-            var eventInfo = WindowsHelper.WpfApplication.GetType().GetEvent("DispatcherUnhandledException");
+            if (WindowsHelper.IsRunningAsWpf)
+            {
+                var eventInfo = WindowsHelper.WpfApplication.GetType().GetEvent("DispatcherUnhandledException");
 
-            EventHandler<object> eventHandler = (sender, eventArgs) =>
-            { 
-                var exceptionProperty = eventArgs.GetType().GetProperty("Exception");
-                var exception = (Exception)exceptionProperty.GetValue(eventArgs);
-                InvokeUnhandledExceptionOccurred(sender, new UnhandledExceptionOccurredEventArgs(exception));
-            };
+                EventHandler<object> eventHandler = (sender, eventArgs) =>
+                { 
+                    var exceptionProperty = eventArgs.GetType().GetProperty("Exception");
+                    var exception = (Exception)exceptionProperty.GetValue(eventArgs);
+                    InvokeUnhandledExceptionOccurred(sender, new UnhandledExceptionOccurredEventArgs(exception));
+                };
 
-            var eventHandlerType = eventInfo.EventHandlerType;
-            var runtimeDelegate = Delegate.CreateDelegate(eventHandlerType, eventHandler.Target, eventHandler.Method);
+                var eventHandlerType = eventInfo.EventHandlerType;
+                var runtimeDelegate = Delegate.CreateDelegate(eventHandlerType, eventHandler.Target, eventHandler.Method);
 
-            eventInfo.AddEventHandler(WindowsHelper.WpfApplication, runtimeDelegate);
+                eventInfo.AddEventHandler(WindowsHelper.WpfApplication, runtimeDelegate);
+            }
+            else 
+            {
+                AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+                {
+                    InvokeUnhandledExceptionOccurred(sender, new UnhandledExceptionOccurredEventArgs((Exception)eventArgs.ExceptionObject));
+                };
+            }
         }
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelperDesktop.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelperDesktop.cs
@@ -42,10 +42,19 @@ namespace Microsoft.AppCenter.Utils
 
         public ApplicationLifecycleHelperDesktop()
         {
-            AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
-            {
-               InvokeUnhandledExceptionOccurred(sender, new UnhandledExceptionOccurredEventArgs((Exception)eventArgs.ExceptionObject));
+            var eventInfo = WindowsHelper.WpfApplication.GetType().GetEvent("DispatcherUnhandledException");
+
+            EventHandler<object> eventHandler = (sender, eventArgs) =>
+            { 
+                var exceptionProperty = eventArgs.GetType().GetProperty("Exception");
+                var exception = (Exception)exceptionProperty.GetValue(eventArgs);
+                InvokeUnhandledExceptionOccurred(sender, new UnhandledExceptionOccurredEventArgs(exception));
             };
+
+            var eventHandlerType = eventInfo.EventHandlerType;
+            var runtimeDelegate = Delegate.CreateDelegate(eventHandlerType, eventHandler.Target, eventHandler.Method);
+
+            eventInfo.AddEventHandler(WindowsHelper.WpfApplication, runtimeDelegate);
         }
     }
 }

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelperDesktop.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/ApplicationLifecycleHelperDesktop.cs
@@ -53,9 +53,7 @@ namespace Microsoft.AppCenter.Utils
                     InvokeUnhandledExceptionOccurred(sender, new UnhandledExceptionOccurredEventArgs(exception));
                 };
 
-                var eventHandlerType = eventInfo.EventHandlerType;
-                var runtimeDelegate = Delegate.CreateDelegate(eventHandlerType, eventHandler.Target, eventHandler.Method);
-
+                var runtimeDelegate = Delegate.CreateDelegate(eventInfo.EventHandlerType, eventHandler.Target, eventHandler.Method);
                 eventInfo.AddEventHandler(WindowsHelper.WpfApplication, runtimeDelegate);
             }
             else 

--- a/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
+++ b/SDK/AppCenter/Microsoft.AppCenter.WindowsDesktop/Utils/WindowsHelper.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AppCenter.Utils
 
         public static bool IsRunningAsWinUI { get; }
 
+        public static dynamic WpfApplication { get; }
+
         #region IsRunningAsUwp
 
         const long APPMODEL_ERROR_NO_PACKAGE = 15700L;
@@ -126,8 +128,6 @@ namespace Microsoft.AppCenter.Utils
             IsRunningAsUwp = _IsRunningAsUwp();
             IsRunningAsWinUI = IsRunningAsUwp || GetAssembly("System.Windows.Forms") == null;
         }
-
-        private static dynamic WpfApplication { get; }
 
         // Store the int corresponding to the "Minimized" state for WPF Windows
         // This is equivalent to `System.Windows.WindowState.Minimized`


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Use `DispatcherUnhandledException` instead of `AppDomain.CurrentDomain.UnhandledException` using reflection.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-dotnet/issues/1727
