### PR TITLE
Add SmartLink=false for macos target

### DIFF
--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.Mono.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.Mono.csproj
@@ -33,6 +33,7 @@
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lc++</LinkerFlags>
       <IsCxx>True</IsCxx>
+      <SmartLink>False</SmartLink>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.csproj
@@ -36,6 +36,7 @@
       <ForceLoad>True</ForceLoad>
       <LinkerFlags>-lc++</LinkerFlags>
       <IsCxx>True</IsCxx>
+      <SmartLink>False</SmartLink>
     </NativeReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests if this modifies the Windows code?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The SmartLink properties have been removed in [this GitHub pull request](https://github.com/microsoft/appcenter-sdk-dotnet/pull/1729). However, it seems to be causing issues with macOS app validation for the App Store.

The previous pull request was not confirmed to have fixed any actual issues; it was based on the assumption that in some cases, the iOS app might not be able to compile due to the SmartLink flag being set to false. The change in the macOS app was made for consistency, so reverting this change should not cause any issues.

## Related PRs or issues

[AB#103183](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/103183)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1753/
