### PR TITLE
[Apple] Add Privacy Manifest

### DIFF
--- a/SDK/AppCenter/Microsoft.AppCenter.Apple/Microsoft.AppCenter.Apple.Mono.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.Apple/Microsoft.AppCenter.Apple.Mono.csproj
@@ -38,4 +38,7 @@
       <Frameworks>CoreTelephony Security SystemConfiguration</Frameworks>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenter.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
 </Project>

--- a/SDK/AppCenter/Microsoft.AppCenter.Apple/Microsoft.AppCenter.Apple.csproj
+++ b/SDK/AppCenter/Microsoft.AppCenter.Apple/Microsoft.AppCenter.Apple.csproj
@@ -46,4 +46,7 @@
       <Frameworks>CoreTelephony Security SystemConfiguration</Frameworks>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenter.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
 </Project>

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Apple/Microsoft.AppCenter.Analytics.Apple.Mono.csproj
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Apple/Microsoft.AppCenter.Analytics.Apple.Mono.csproj
@@ -31,6 +31,9 @@
       <Frameworks>IOKit</Frameworks>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenterAnalytics.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AppCenter\Microsoft.AppCenter.Apple\Microsoft.AppCenter.Apple.Mono.csproj" />
   </ItemGroup>

--- a/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Apple/Microsoft.AppCenter.Analytics.Apple.csproj
+++ b/SDK/AppCenterAnalytics/Microsoft.AppCenter.Analytics.Apple/Microsoft.AppCenter.Analytics.Apple.csproj
@@ -41,6 +41,9 @@
       <Frameworks>IOKit</Frameworks>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenterAnalytics.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AppCenter\Microsoft.AppCenter.Apple\Microsoft.AppCenter.Apple.csproj" />
   </ItemGroup>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.Mono.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.Mono.csproj
@@ -35,6 +35,9 @@
       <IsCxx>True</IsCxx>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenterCrashes.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AppCenter\Microsoft.AppCenter.Apple\Microsoft.AppCenter.Apple.Mono.csproj" />
   </ItemGroup>

--- a/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.csproj
+++ b/SDK/AppCenterCrashes/Microsoft.AppCenter.Crashes.Apple/Microsoft.AppCenter.Crashes.Apple.csproj
@@ -46,6 +46,9 @@
       <IsCxx>True</IsCxx>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenterCrashes.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AppCenter\Microsoft.AppCenter.Apple\Microsoft.AppCenter.Apple.csproj" />
   </ItemGroup>

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Apple/Microsoft.AppCenter.Distribute.Apple.Mono.csproj
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Apple/Microsoft.AppCenter.Distribute.Apple.Mono.csproj
@@ -30,6 +30,9 @@
       <Link>Resources\AppCenterDistributeResources.bundle\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </BundleResource>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenterDistribute.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AppCenter\Microsoft.AppCenter.Apple\Microsoft.AppCenter.Apple.Mono.csproj" />
   </ItemGroup>

--- a/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Apple/Microsoft.AppCenter.Distribute.Apple.csproj
+++ b/SDK/AppCenterDistribute/Microsoft.AppCenter.Distribute.Apple/Microsoft.AppCenter.Distribute.Apple.csproj
@@ -29,6 +29,9 @@
       <Link>Resources\AppCenterDistributeResources.bundle\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </BundleResource>
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <BundleResource Include="..\..\..\externals\apple\AppCenter-SDK-Apple\iOS\AppCenterDistribute.framework\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AppCenter\Microsoft.AppCenter.Apple\Microsoft.AppCenter.Apple.csproj" />
   </ItemGroup>


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated? (it's updated in master already 😂)
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests if this modifies the Windows code?~
* ~[] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

The PrivacyInfo.xcprivacy is taken from the apple native framework. As Dotnet SDK is just a binding project, we don't need to have a separate privacy manifest.

## Related PRs or issues

[AB#104301](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/104301)
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1775
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1526436&view=results)