### PR TITLE
Rename aar files

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -102,10 +102,9 @@ Task("Externals-Android")
 
     // fix since aar files contain version name instead of release string
     foreach (var file in files)
-    {
-        if (file.Contains($"{VersionReader.AndroidVersion}"))
+    {   var filename = file.GetFilename();
+        if (filename.Contains($"{VersionReader.AndroidVersion}"))
         {
-            var filename = file.GetFilename();
             var replacedName = filename.Replace($"{VersionReader.AndroidVersion}", "release");
             MoveFile(file, $"{AndroidExternals}/{replacedName}");
         }

--- a/build.cake
+++ b/build.cake
@@ -102,7 +102,8 @@ Task("Externals-Android")
 
     // fix since aar files contain version name instead of release string
     foreach (var file in files)
-    {   var filename = file.GetFilename();
+    {
+        var filename = file.GetFilename().ToString();
         if (filename.Contains($"{VersionReader.AndroidVersion}"))
         {
             var replacedName = filename.Replace($"{VersionReader.AndroidVersion}", "release");

--- a/build.cake
+++ b/build.cake
@@ -98,7 +98,9 @@ Task("Externals-Android")
 
     // Move binaries to externals/android so that linked files don't have versions
     // in their paths
-    var files = GetFiles($"{AndroidExternals}/*");
+
+    var androidExternalsPath = System.IO.Path.Combine(AndroidExternals, "*");
+    var files = GetFiles(androidExternalsPath);
 
     // fix since aar files contain version name instead of release string
     foreach (var file in files)
@@ -107,7 +109,8 @@ Task("Externals-Android")
         if (filename.Contains($"{VersionReader.AndroidVersion}"))
         {
             var replacedName = filename.Replace($"{VersionReader.AndroidVersion}", "release");
-            MoveFile(file, $"{AndroidExternals}/{replacedName}");
+            var newPath = System.IO.Path.Combine(AndroidExternals, replacedName);
+            MoveFile(file, newPath);
         }
     }
 

--- a/build.cake
+++ b/build.cake
@@ -98,7 +98,7 @@ Task("Externals-Android")
 
     // Move binaries to externals/android so that linked files don't have versions
     // in their paths
-    var files = GetFiles($"{AndroidExternals}/*/*");
+    var files = GetFiles($"{AndroidExternals}/*");
 
     // fix since aar files contain version name instead of release string
     foreach (var file in files)
@@ -111,7 +111,6 @@ Task("Externals-Android")
         }
     }
 
-    CopyFiles(files, AndroidExternals);
 }).OnError(HandleError);
 
 public static void UnzipFile(this ICakeContext context, string zipFile, string outputPath)


### PR DESCRIPTION
Rename aar files  from appcenter-crashes-X.X.X.aar to appcenter-crashes-release.aar to match the naming in dotnet sdk

[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1545527&view=results)