### PR TITLE
Use macos 13

### DIFF
--- a/.azurepipelines/build-release-packages-1es.yml
+++ b/.azurepipelines/build-release-packages-1es.yml
@@ -76,7 +76,7 @@ extends:
       dependsOn: []
       pool:
         name: Azure Pipelines
-        image: macos-12
+        image: macos-13
         os: macOS
         demands:
         - msbuild


### PR DESCRIPTION
## Description
Use macOS 13 image since macOS 12 is deprecated and will be completely removed on 3rd December.

[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1546677&view=results)

