### PR TITLE
[CI] Fix issue with externals-android cake task

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -97,13 +97,16 @@ Task("Externals-Android")
     var androidExternalsPath = System.IO.Path.Combine(AndroidExternals, "*");
     var files = GetFiles(androidExternalsPath);
 
+    // regex pattern for extracting version
+    var versionPattern = new System.Text.RegularExpressions.Regex(@"\d+\.\d+\.\d+");
+
     // fix since aar files contain version name instead of release string
     foreach (var file in files)
     {
         var filename = file.GetFilename().ToString();
-        if (filename.Contains($"{VersionReader.AndroidVersion}"))
+        if (versionPattern.IsMatch(filename))
         {
-            var replacedName = filename.Replace($"{VersionReader.AndroidVersion}", "release");
+            var replacedName = versionPattern.Replace(filename, "release");
             var newPath = System.IO.Path.Combine(AndroidExternals, replacedName);
             MoveFile(file, newPath);
         }


### PR DESCRIPTION
## Description
Since we moved to usage of build pipeline artifacts rather than blob storage, we can't explicitly target specific version of android sdk. Added regex pattern for matching version of android-externals task in order to successfully rename aar binaries.
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1554066&view=results)